### PR TITLE
feat(#97): Pipeline para scrapy - back

### DIFF
--- a/backend/src/main/java/com/versus/api/ApiApplication.java
+++ b/backend/src/main/java/com/versus/api/ApiApplication.java
@@ -2,8 +2,10 @@ package com.versus.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class ApiApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/versus/api/config/SecurityConfig.java
+++ b/backend/src/main/java/com/versus/api/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .exceptionHandling(eh -> eh
                         .authenticationEntryPoint((req, res, ex) -> {

--- a/backend/src/main/java/com/versus/api/questions/domain/Question.java
+++ b/backend/src/main/java/com/versus/api/questions/domain/Question.java
@@ -57,6 +57,9 @@ public class Question {
     @Column(name = "tolerance_percent", precision = 6, scale = 2)
     private BigDecimal tolerancePercent;
 
+    @Column(name = "text_hash", length = 64, unique = true)
+    private String textHash;
+
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default
     private List<QuestionOption> options = new ArrayList<>();

--- a/backend/src/main/java/com/versus/api/scraping/SpiderController.java
+++ b/backend/src/main/java/com/versus/api/scraping/SpiderController.java
@@ -1,0 +1,52 @@
+package com.versus.api.scraping;
+
+import com.versus.api.scraping.dto.SpiderResponse;
+import com.versus.api.scraping.dto.SpiderRunResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Admin — Spiders", description = "Spider management (ADMIN only)")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/admin/spiders")
+@RequiredArgsConstructor
+public class SpiderController {
+
+    private final SpiderService spiderService;
+
+    @Operation(summary = "List all spiders with their last run status",
+            responses = @ApiResponse(responseCode = "200", description = "Spider list returned"))
+    @GetMapping
+    public List<SpiderResponse> list() {
+        return spiderService.listSpiders();
+    }
+
+    @Operation(summary = "Trigger a spider run by name",
+            responses = {
+                @ApiResponse(responseCode = "202", description = "Run started"),
+                @ApiResponse(responseCode = "404", description = "Spider not found"),
+                @ApiResponse(responseCode = "409", description = "Spider already running")
+            })
+    @PostMapping("/{name}/run")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public SpiderRunResponse run(@PathVariable String name) {
+        return spiderService.triggerRun(name);
+    }
+
+    @Operation(summary = "Get run history for a spider",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "Run history returned"),
+                @ApiResponse(responseCode = "404", description = "Spider not found")
+            })
+    @GetMapping("/{name}/runs")
+    public List<SpiderRunResponse> runs(@PathVariable String name) {
+        return spiderService.getRunHistory(name);
+    }
+}

--- a/backend/src/main/java/com/versus/api/scraping/SpiderService.java
+++ b/backend/src/main/java/com/versus/api/scraping/SpiderService.java
@@ -1,0 +1,133 @@
+package com.versus.api.scraping;
+
+import com.versus.api.common.exception.ApiException;
+import com.versus.api.scraping.domain.Spider;
+import com.versus.api.scraping.domain.SpiderRun;
+import com.versus.api.scraping.dto.SpiderResponse;
+import com.versus.api.scraping.dto.SpiderRunResponse;
+import com.versus.api.scraping.repo.SpiderRepository;
+import com.versus.api.scraping.repo.SpiderRunRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpiderService {
+
+    private final SpiderRepository spiders;
+    private final SpiderRunRepository spiderRuns;
+
+    @Value("${scraper.working-dir:../scraper}")
+    private String scraperWorkingDir;
+
+    // ── List ──────────────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public List<SpiderResponse> listSpiders() {
+        return spiders.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    // ── Run ───────────────────────────────────────────────────────────────────
+
+    @Transactional
+    public SpiderRunResponse triggerRun(String name) {
+        Spider spider = spiders.findByName(name)
+                .orElseThrow(() -> ApiException.notFound("Spider not found: " + name));
+
+        if (spider.getStatus() == SpiderStatus.RUNNING) {
+            throw ApiException.conflict("Spider '" + name + "' is already running");
+        }
+
+        spider.setStatus(SpiderStatus.RUNNING);
+        spider.setLastRunAt(Instant.now());
+        spiders.save(spider);
+
+        SpiderRun run = SpiderRun.builder()
+                .spiderId(spider.getId())
+                .startedAt(Instant.now())
+                .questionsInserted(0)
+                .errors(0)
+                .build();
+        spiderRuns.save(run);
+
+        launchProcess(spider.getId(), run.getId(), name);
+
+        return toRunResponse(run);
+    }
+
+    // ── Run history ───────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public List<SpiderRunResponse> getRunHistory(String name) {
+        Spider spider = spiders.findByName(name)
+                .orElseThrow(() -> ApiException.notFound("Spider not found: " + name));
+        return spiderRuns.findBySpiderIdOrderByStartedAtDesc(spider.getId())
+                .stream()
+                .map(this::toRunResponse)
+                .toList();
+    }
+
+    // ── Async process ─────────────────────────────────────────────────────────
+
+    @Async
+    protected void launchProcess(UUID spiderId, UUID runId, String spiderName) {
+        SpiderRun run = spiderRuns.findById(runId).orElse(null);
+        Spider spider = spiders.findById(spiderId).orElse(null);
+        if (run == null || spider == null) return;
+
+        int exitCode = -1;
+        try {
+            ProcessBuilder pb = new ProcessBuilder("scrapy", "crawl", spiderName);
+            pb.directory(new java.io.File(scraperWorkingDir));
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+            exitCode = process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            log.error("Error launching spider '{}': {}", spiderName, e.getMessage());
+            Thread.currentThread().interrupt();
+        } finally {
+            run.setFinishedAt(Instant.now());
+            spider.setStatus(exitCode == 0 ? SpiderStatus.IDLE : SpiderStatus.FAILED);
+            spiderRuns.save(run);
+            spiders.save(spider);
+        }
+    }
+
+    // ── Mappers ───────────────────────────────────────────────────────────────
+
+    private SpiderResponse toResponse(Spider spider) {
+        SpiderRun lastRun = spiderRuns
+                .findFirstBySpiderIdOrderByStartedAtDesc(spider.getId())
+                .orElse(null);
+        return new SpiderResponse(
+                spider.getId(),
+                spider.getName(),
+                spider.getTargetUrl(),
+                spider.getStatus(),
+                spider.getLastRunAt(),
+                lastRun != null ? toRunResponse(lastRun) : null
+        );
+    }
+
+    private SpiderRunResponse toRunResponse(SpiderRun run) {
+        return new SpiderRunResponse(
+                run.getId(),
+                run.getStartedAt(),
+                run.getFinishedAt(),
+                run.getQuestionsInserted(),
+                run.getErrors()
+        );
+    }
+}

--- a/backend/src/main/java/com/versus/api/scraping/dto/SpiderResponse.java
+++ b/backend/src/main/java/com/versus/api/scraping/dto/SpiderResponse.java
@@ -1,0 +1,15 @@
+package com.versus.api.scraping.dto;
+
+import com.versus.api.scraping.SpiderStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SpiderResponse(
+        UUID id,
+        String name,
+        String targetUrl,
+        SpiderStatus status,
+        Instant lastRunAt,
+        SpiderRunResponse lastRun
+) {}

--- a/backend/src/main/java/com/versus/api/scraping/dto/SpiderRunResponse.java
+++ b/backend/src/main/java/com/versus/api/scraping/dto/SpiderRunResponse.java
@@ -1,0 +1,12 @@
+package com.versus.api.scraping.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SpiderRunResponse(
+        UUID id,
+        Instant startedAt,
+        Instant finishedAt,
+        Integer questionsInserted,
+        Integer errors
+) {}

--- a/backend/src/main/java/com/versus/api/scraping/repo/SpiderRepository.java
+++ b/backend/src/main/java/com/versus/api/scraping/repo/SpiderRepository.java
@@ -3,7 +3,10 @@ package com.versus.api.scraping.repo;
 import com.versus.api.scraping.domain.Spider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface SpiderRepository extends JpaRepository<Spider, UUID> {
+
+    Optional<Spider> findByName(String name);
 }

--- a/backend/src/main/java/com/versus/api/scraping/repo/SpiderRunRepository.java
+++ b/backend/src/main/java/com/versus/api/scraping/repo/SpiderRunRepository.java
@@ -3,7 +3,13 @@ package com.versus.api.scraping.repo;
 import com.versus.api.scraping.domain.SpiderRun;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface SpiderRunRepository extends JpaRepository<SpiderRun, UUID> {
+
+    List<SpiderRun> findBySpiderIdOrderByStartedAtDesc(UUID spiderId);
+
+    Optional<SpiderRun> findFirstBySpiderIdOrderByStartedAtDesc(UUID spiderId);
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,4 +17,6 @@ versus.jwt.refresh-expiry=${JWT_REFRESH_EXPIRY:604800}
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 
+scraper.working-dir=${SCRAPER_DIR:../scraper}
+
 server.error.include-message=always

--- a/backend/src/test/java/com/versus/api/scraping/SpiderServiceTest.java
+++ b/backend/src/test/java/com/versus/api/scraping/SpiderServiceTest.java
@@ -1,0 +1,577 @@
+package com.versus.api.scraping;
+
+import com.versus.api.common.exception.ApiException;
+import com.versus.api.common.exception.ErrorCode;
+import com.versus.api.scraping.domain.Spider;
+import com.versus.api.scraping.domain.SpiderRun;
+import com.versus.api.scraping.dto.SpiderResponse;
+import com.versus.api.scraping.dto.SpiderRunResponse;
+import com.versus.api.scraping.repo.SpiderRepository;
+import com.versus.api.scraping.repo.SpiderRunRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("SpiderService")
+@ExtendWith(MockitoExtension.class)
+class SpiderServiceTest {
+
+    @Mock SpiderRepository spiders;
+    @Mock SpiderRunRepository spiderRuns;
+
+    @InjectMocks SpiderService spiderService;
+
+    private static final UUID SPIDER_ID = UUID.fromString("aaaa0000-0000-0000-0000-000000000001");
+    private static final UUID RUN_ID    = UUID.fromString("bbbb0000-0000-0000-0000-000000000002");
+
+    // ── Factories ─────────────────────────────────────────────────────────────
+
+    private Spider spider(String name, SpiderStatus status) {
+        return Spider.builder()
+                .id(SPIDER_ID)
+                .name(name)
+                .targetUrl("https://example.com/" + name)
+                .status(status)
+                .lastRunAt(null)
+                .managedBy(null)
+                .build();
+    }
+
+    private SpiderRun finishedRun() {
+        return SpiderRun.builder()
+                .id(RUN_ID)
+                .spiderId(SPIDER_ID)
+                .startedAt(Instant.parse("2026-01-01T10:00:00Z"))
+                .finishedAt(Instant.parse("2026-01-01T10:05:00Z"))
+                .questionsInserted(42)
+                .errors(3)
+                .build();
+    }
+
+    private SpiderRun runInProgress() {
+        return SpiderRun.builder()
+                .id(RUN_ID)
+                .spiderId(SPIDER_ID)
+                .startedAt(Instant.now())
+                .questionsInserted(0)
+                .errors(0)
+                .build();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // listSpiders
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @DisplayName("listSpiders")
+    @Nested
+    class ListSpiders {
+
+        @DisplayName("Sin spiders registrados devuelve lista vacía")
+        @Test
+        void sinSpiders_devuelveListaVacia() {
+            when(spiders.findAll()).thenReturn(List.of());
+
+            assertThat(spiderService.listSpiders()).isEmpty();
+        }
+
+        @DisplayName("Un spider sin runs devuelve lastRun null")
+        @Test
+        void spiderSinRuns_lastRunEsNull() {
+            when(spiders.findAll()).thenReturn(List.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiderRuns.findFirstBySpiderIdOrderByStartedAtDesc(SPIDER_ID))
+                    .thenReturn(Optional.empty());
+
+            SpiderResponse res = spiderService.listSpiders().get(0);
+
+            assertThat(res.lastRun()).isNull();
+        }
+
+        @DisplayName("Un spider con runs devuelve el último run en lastRun")
+        @Test
+        void spiderConRuns_lastRunPopulado() {
+            SpiderRun run = finishedRun();
+            when(spiders.findAll()).thenReturn(List.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiderRuns.findFirstBySpiderIdOrderByStartedAtDesc(SPIDER_ID))
+                    .thenReturn(Optional.of(run));
+
+            SpiderResponse res = spiderService.listSpiders().get(0);
+
+            assertThat(res.lastRun()).isNotNull();
+            assertThat(res.lastRun().id()).isEqualTo(RUN_ID);
+        }
+
+        @DisplayName("Varios spiders devuelven una respuesta por cada uno")
+        @Test
+        void variosSpiders_devuelveUnoporCadaSpider() {
+            Spider s1 = spider("rrss", SpiderStatus.IDLE);
+            Spider s2 = Spider.builder().id(UUID.randomUUID()).name("futbol")
+                    .targetUrl("https://fbref.com").status(SpiderStatus.FAILED)
+                    .build();
+            when(spiders.findAll()).thenReturn(List.of(s1, s2));
+            when(spiderRuns.findFirstBySpiderIdOrderByStartedAtDesc(any()))
+                    .thenReturn(Optional.empty());
+
+            assertThat(spiderService.listSpiders()).hasSize(2);
+        }
+
+        @DisplayName("Los campos del SpiderResponse coinciden con los datos del spider")
+        @Test
+        void camposMapeadosCorrectamente() {
+            Spider s = spider("rrss", SpiderStatus.IDLE);
+            s.setLastRunAt(Instant.parse("2026-05-01T12:00:00Z"));
+            when(spiders.findAll()).thenReturn(List.of(s));
+            when(spiderRuns.findFirstBySpiderIdOrderByStartedAtDesc(SPIDER_ID))
+                    .thenReturn(Optional.empty());
+
+            SpiderResponse res = spiderService.listSpiders().get(0);
+
+            assertThat(res.id()).isEqualTo(SPIDER_ID);
+            assertThat(res.name()).isEqualTo("rrss");
+            assertThat(res.targetUrl()).isEqualTo("https://example.com/rrss");
+            assertThat(res.status()).isEqualTo(SpiderStatus.IDLE);
+            assertThat(res.lastRunAt()).isEqualTo(Instant.parse("2026-05-01T12:00:00Z"));
+        }
+
+        @DisplayName("Los campos del SpiderRunResponse del lastRun son correctos")
+        @Test
+        void camposLastRunMapeadosCorrectamente() {
+            SpiderRun run = finishedRun();
+            when(spiders.findAll()).thenReturn(List.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiderRuns.findFirstBySpiderIdOrderByStartedAtDesc(SPIDER_ID))
+                    .thenReturn(Optional.of(run));
+
+            SpiderRunResponse lastRun = spiderService.listSpiders().get(0).lastRun();
+
+            assertThat(lastRun.startedAt()).isEqualTo(Instant.parse("2026-01-01T10:00:00Z"));
+            assertThat(lastRun.finishedAt()).isEqualTo(Instant.parse("2026-01-01T10:05:00Z"));
+            assertThat(lastRun.questionsInserted()).isEqualTo(42);
+            assertThat(lastRun.errors()).isEqualTo(3);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // triggerRun
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @DisplayName("triggerRun")
+    @Nested
+    class TriggerRun {
+
+        private SpiderService svc;
+
+        @BeforeEach
+        void setUp() {
+            svc = spy(new SpiderService(spiders, spiderRuns));
+            ReflectionTestUtils.setField(svc, "scraperWorkingDir", "/tmp/test-scraper");
+            lenient().doNothing().when(svc).launchProcess(any(), any(), any());
+        }
+
+        @DisplayName("Spider no encontrado lanza NOT_FOUND")
+        @Test
+        void spiderNoEncontrado_lanzaNotFound() {
+            when(spiders.findByName("desconocido")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> svc.triggerRun("desconocido"))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(e -> assertThat(((ApiException) e).getCode())
+                            .isEqualTo(ErrorCode.NOT_FOUND));
+        }
+
+        @DisplayName("Spider ya en estado RUNNING lanza CONFLICT")
+        @Test
+        void spiderEnEstadoRunning_lanzaConflict() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.RUNNING)));
+
+            assertThatThrownBy(() -> svc.triggerRun("rrss"))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(e -> assertThat(((ApiException) e).getCode())
+                            .isEqualTo(ErrorCode.CONFLICT));
+        }
+
+        @DisplayName("Spider en estado IDLE puede lanzarse sin conflicto")
+        @Test
+        void spiderEnEstadoIdle_puedeLanzarse() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThatCode(() -> svc.triggerRun("rrss")).doesNotThrowAnyException();
+        }
+
+        @DisplayName("Spider en estado FAILED puede relanzarse sin conflicto")
+        @Test
+        void spiderEnEstadoFailed_puedeRelanzarse() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.FAILED)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThatCode(() -> svc.triggerRun("rrss")).doesNotThrowAnyException();
+        }
+
+        @DisplayName("El estado del spider se actualiza a RUNNING antes de devolver")
+        @Test
+        void caminoFeliz_estadoActualizadoARunning() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            svc.triggerRun("rrss");
+
+            ArgumentCaptor<Spider> cap = ArgumentCaptor.forClass(Spider.class);
+            verify(spiders).save(cap.capture());
+            assertThat(cap.getValue().getStatus()).isEqualTo(SpiderStatus.RUNNING);
+        }
+
+        @DisplayName("El lastRunAt del spider se actualiza al lanzar")
+        @Test
+        void caminoFeliz_lastRunAtActualizado() {
+            Spider s = spider("rrss", SpiderStatus.IDLE);
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(s));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            Instant before = Instant.now();
+            svc.triggerRun("rrss");
+
+            assertThat(s.getLastRunAt()).isNotNull();
+            assertThat(s.getLastRunAt()).isAfterOrEqualTo(before);
+        }
+
+        @DisplayName("El SpiderRun se crea con el spiderId del spider encontrado")
+        @Test
+        void caminoFeliz_spiderRunCreadoConSpiderId() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            svc.triggerRun("rrss");
+
+            ArgumentCaptor<SpiderRun> cap = ArgumentCaptor.forClass(SpiderRun.class);
+            verify(spiderRuns).save(cap.capture());
+            assertThat(cap.getValue().getSpiderId()).isEqualTo(SPIDER_ID);
+        }
+
+        @DisplayName("El SpiderRun inicial tiene questionsInserted=0")
+        @Test
+        void caminoFeliz_questionsInsertedInicialEsCero() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            SpiderRunResponse res = svc.triggerRun("rrss");
+
+            assertThat(res.questionsInserted()).isZero();
+        }
+
+        @DisplayName("El SpiderRun inicial tiene errors=0")
+        @Test
+        void caminoFeliz_errorsInicialesEsCero() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            SpiderRunResponse res = svc.triggerRun("rrss");
+
+            assertThat(res.errors()).isZero();
+        }
+
+        @DisplayName("La respuesta contiene startedAt no nulo")
+        @Test
+        void caminoFeliz_respuestaConStartedAtNoNull() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            SpiderRunResponse res = svc.triggerRun("rrss");
+
+            assertThat(res.startedAt()).isNotNull();
+        }
+
+        @DisplayName("La respuesta tiene finishedAt null (el proceso aún no ha terminado)")
+        @Test
+        void caminoFeliz_finishedAtInicialmenteNull() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            SpiderRunResponse res = svc.triggerRun("rrss");
+
+            assertThat(res.finishedAt()).isNull();
+        }
+
+        @DisplayName("launchProcess se invoca con el spiderId, runId y nombre correctos")
+        @Test
+        void caminoFeliz_launchProcessInvocadoConParametrosCorrectos() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            svc.triggerRun("rrss");
+
+            verify(svc).launchProcess(eq(SPIDER_ID), any(), eq("rrss"));
+        }
+
+        @DisplayName("El SpiderRun se persiste en el repositorio exactamente una vez")
+        @Test
+        void caminoFeliz_spiderRunGuardadoExactamenteUnaVez() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiders.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(spiderRuns.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            svc.triggerRun("rrss");
+
+            verify(spiderRuns, times(1)).save(any(SpiderRun.class));
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // getRunHistory
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @DisplayName("getRunHistory")
+    @Nested
+    class GetRunHistory {
+
+        @DisplayName("Spider no encontrado lanza NOT_FOUND")
+        @Test
+        void spiderNoEncontrado_lanzaNotFound() {
+            when(spiders.findByName("desconocido")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> spiderService.getRunHistory("desconocido"))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(e -> assertThat(((ApiException) e).getCode())
+                            .isEqualTo(ErrorCode.NOT_FOUND));
+        }
+
+        @DisplayName("Sin runs devuelve lista vacía")
+        @Test
+        void sinRuns_devuelveListaVacia() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiderRuns.findBySpiderIdOrderByStartedAtDesc(SPIDER_ID)).thenReturn(List.of());
+
+            assertThat(spiderService.getRunHistory("rrss")).isEmpty();
+        }
+
+        @DisplayName("Con runs devuelve un SpiderRunResponse por cada run")
+        @Test
+        void conRuns_devuelveUnoporCadaRun() {
+            SpiderRun r1 = finishedRun();
+            SpiderRun r2 = SpiderRun.builder().id(UUID.randomUUID()).spiderId(SPIDER_ID)
+                    .startedAt(Instant.parse("2026-01-02T10:00:00Z"))
+                    .finishedAt(Instant.parse("2026-01-02T10:03:00Z"))
+                    .questionsInserted(7).errors(0).build();
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiderRuns.findBySpiderIdOrderByStartedAtDesc(SPIDER_ID)).thenReturn(List.of(r1, r2));
+
+            assertThat(spiderService.getRunHistory("rrss")).hasSize(2);
+        }
+
+        @DisplayName("Los campos del SpiderRunResponse coinciden con los datos del run")
+        @Test
+        void camposMapeadosCorrectamente() {
+            SpiderRun run = finishedRun();
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiderRuns.findBySpiderIdOrderByStartedAtDesc(SPIDER_ID)).thenReturn(List.of(run));
+
+            SpiderRunResponse res = spiderService.getRunHistory("rrss").get(0);
+
+            assertThat(res.id()).isEqualTo(RUN_ID);
+            assertThat(res.startedAt()).isEqualTo(Instant.parse("2026-01-01T10:00:00Z"));
+            assertThat(res.finishedAt()).isEqualTo(Instant.parse("2026-01-01T10:05:00Z"));
+            assertThat(res.questionsInserted()).isEqualTo(42);
+            assertThat(res.errors()).isEqualTo(3);
+        }
+
+        @DisplayName("Un run activo (finishedAt null) se mapea con finishedAt null")
+        @Test
+        void runActivoConFinishedAtNull_seMapeaComoNull() {
+            SpiderRun active = runInProgress();
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.RUNNING)));
+            when(spiderRuns.findBySpiderIdOrderByStartedAtDesc(SPIDER_ID)).thenReturn(List.of(active));
+
+            SpiderRunResponse res = spiderService.getRunHistory("rrss").get(0);
+
+            assertThat(res.finishedAt()).isNull();
+        }
+
+        @DisplayName("El orden de los runs es delegado al repositorio")
+        @Test
+        void ordenDelegadoAlRepositorio() {
+            when(spiders.findByName("rrss")).thenReturn(Optional.of(spider("rrss", SpiderStatus.IDLE)));
+            when(spiderRuns.findBySpiderIdOrderByStartedAtDesc(SPIDER_ID)).thenReturn(List.of());
+
+            spiderService.getRunHistory("rrss");
+
+            verify(spiderRuns).findBySpiderIdOrderByStartedAtDesc(SPIDER_ID);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // launchProcess
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @DisplayName("launchProcess")
+    @Nested
+    class LaunchProcessTests {
+
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(spiderService, "scraperWorkingDir", "/tmp/test-scraper");
+        }
+
+        @DisplayName("Run no encontrado: retorna silenciosamente sin guardar nada")
+        @Test
+        void runNoEncontrado_retornaSilenciosamente() {
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.empty());
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.of(spider("rrss", SpiderStatus.RUNNING)));
+
+            spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+
+            verify(spiderRuns, never()).save(any());
+            verify(spiders, never()).save(any());
+        }
+
+        @DisplayName("Spider no encontrado: retorna silenciosamente sin guardar nada")
+        @Test
+        void spiderNoEncontrado_retornaSilenciosamente() {
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.of(runInProgress()));
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.empty());
+
+            spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+
+            verify(spiderRuns, never()).save(any());
+            verify(spiders, never()).save(any());
+        }
+
+        @DisplayName("exitCode=0: estado del spider pasa a IDLE")
+        @Test
+        void exitCodeCero_estableceSpiderIdle() throws Exception {
+            Spider s = spider("rrss", SpiderStatus.RUNNING);
+            SpiderRun run = runInProgress();
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.of(run));
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.of(s));
+
+            Process mockProcess = mock(Process.class);
+            when(mockProcess.waitFor()).thenReturn(0);
+
+            try (MockedConstruction<ProcessBuilder> ignored = mockConstruction(ProcessBuilder.class,
+                    (mock, ctx) -> when(mock.start()).thenReturn(mockProcess))) {
+                spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+            }
+
+            assertThat(s.getStatus()).isEqualTo(SpiderStatus.IDLE);
+            verify(spiders).save(s);
+        }
+
+        @DisplayName("exitCode!=0: estado del spider pasa a FAILED")
+        @Test
+        void exitCodeNoCero_estableceSpiderFailed() throws Exception {
+            Spider s = spider("rrss", SpiderStatus.RUNNING);
+            SpiderRun run = runInProgress();
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.of(run));
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.of(s));
+
+            Process mockProcess = mock(Process.class);
+            when(mockProcess.waitFor()).thenReturn(1);
+
+            try (MockedConstruction<ProcessBuilder> ignored = mockConstruction(ProcessBuilder.class,
+                    (mock, ctx) -> when(mock.start()).thenReturn(mockProcess))) {
+                spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+            }
+
+            assertThat(s.getStatus()).isEqualTo(SpiderStatus.FAILED);
+        }
+
+        @DisplayName("IOException al arrancar el proceso: spider queda en FAILED")
+        @Test
+        void ioException_estableceSpiderFailed() throws Exception {
+            Spider s = spider("rrss", SpiderStatus.RUNNING);
+            SpiderRun run = runInProgress();
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.of(run));
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.of(s));
+
+            try (MockedConstruction<ProcessBuilder> ignored = mockConstruction(ProcessBuilder.class,
+                    (mock, ctx) -> when(mock.start()).thenThrow(new IOException("scrapy not found")))) {
+                spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+            }
+
+            assertThat(s.getStatus()).isEqualTo(SpiderStatus.FAILED);
+        }
+
+        @DisplayName("finishedAt siempre se establece aunque el proceso falle (bloque finally)")
+        @Test
+        void finishedAt_siempreEstablecido_aunqueFalle() throws Exception {
+            SpiderRun run = runInProgress();
+            assertThat(run.getFinishedAt()).isNull();
+
+            Spider s = spider("rrss", SpiderStatus.RUNNING);
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.of(run));
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.of(s));
+
+            try (MockedConstruction<ProcessBuilder> ignored = mockConstruction(ProcessBuilder.class,
+                    (mock, ctx) -> when(mock.start()).thenThrow(new IOException("fail")))) {
+                spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+            }
+
+            assertThat(run.getFinishedAt()).isNotNull();
+            verify(spiderRuns).save(run);
+        }
+
+        @DisplayName("finishedAt se establece también en el camino feliz")
+        @Test
+        void finishedAt_establecidoEnCaminoFeliz() throws Exception {
+            SpiderRun run = runInProgress();
+            Spider s = spider("rrss", SpiderStatus.RUNNING);
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.of(run));
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.of(s));
+
+            Process mockProcess = mock(Process.class);
+            when(mockProcess.waitFor()).thenReturn(0);
+
+            try (MockedConstruction<ProcessBuilder> ignored = mockConstruction(ProcessBuilder.class,
+                    (mock, ctx) -> when(mock.start()).thenReturn(mockProcess))) {
+                spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+            }
+
+            assertThat(run.getFinishedAt()).isNotNull();
+        }
+
+        @DisplayName("El run se persiste en el repositorio tras la ejecución")
+        @Test
+        void run_persistidoTrasEjecucion() throws Exception {
+            SpiderRun run = runInProgress();
+            Spider s = spider("rrss", SpiderStatus.RUNNING);
+            when(spiderRuns.findById(RUN_ID)).thenReturn(Optional.of(run));
+            when(spiders.findById(SPIDER_ID)).thenReturn(Optional.of(s));
+
+            Process mockProcess = mock(Process.class);
+            when(mockProcess.waitFor()).thenReturn(0);
+
+            try (MockedConstruction<ProcessBuilder> ignored = mockConstruction(ProcessBuilder.class,
+                    (mock, ctx) -> when(mock.start()).thenReturn(mockProcess))) {
+                spiderService.launchProcess(SPIDER_ID, RUN_ID, "rrss");
+            }
+
+            verify(spiderRuns).save(run);
+        }
+    }
+}

--- a/docs/bd-scheme.md
+++ b/docs/bd-scheme.md
@@ -36,6 +36,7 @@ erDiagram
     numeric correct_value
     string unit
     numeric tolerance_percent
+    string text_hash UK
   }
 
   question_options {
@@ -171,10 +172,17 @@ erDiagram
 | `match_answers.is_correct` | Permite filtros y stats sin recalcular desviación. |
 | `matches.owner_user_id` | Identifica al dueño/host (singleplayer = único jugador). |
 
+## Cambios introducidos en issue #97 (Pipeline Scrapy)
+
+| Cambio | Motivo |
+|---|---|
+| `questions.text_hash VARCHAR(64) UNIQUE` | Deduplicación idempotente en el pipeline Scrapy: SHA-256 del texto de la pregunta. Permite ejecutar el mismo spider varias veces sin crear duplicados. |
+
 ## Índices
 
 - `users(email)` UNIQUE, `users(username)` UNIQUE.
 - `questions(status, type, category)` compuesto (filtro frecuente para `/api/questions/random`).
+- `questions(text_hash)` UNIQUE (deduplicación del pipeline Scrapy).
 - `rankings(mode, score DESC)`.
 - `matchmaking_queue(mode, entered_at)`.
 - `match_rounds(match_id)`, `match_answers(round_id)`, `match_answers(user_id)`.

--- a/docs/guia-de-coordinación-técnica.md
+++ b/docs/guia-de-coordinación-técnica.md
@@ -353,7 +353,7 @@ GET /api/stats/me?mode=SURVIVAL
 ---
  
 ## 🕷️ Módulo 7 — SCRAPING
-> Issues: #45, #46, #47, #48, #49, #50, #51, #52
+> Issues: #45, #46, #47, #48, #49, #50, #51, #52, #97, #98
  
 Scrapers en Scrapy que extraen datos reales y los insertan en PostgreSQL como preguntas.
  
@@ -361,19 +361,23 @@ Scrapers en Scrapy que extraen datos reales y los insertan en PostgreSQL como pr
  
 | Spider | Fuente | Tipo pregunta | Issue |
 |--------|--------|---------------|-------|
-| Instagram followers | Instagram/web | NUMERIC | #46 |
-| Estadísticas fútbol | FBref / Transfermarkt | NUMERIC + BINARY | #47 |
-| Taquilla de cine | Box Office Mojo | NUMERIC | #48 |
-| Capitales y geografía | Wikipedia | BINARY | #49 |
-| Récords varios | Wikipedia / Guinness | NUMERIC | #50 |
+| RRSS (YouTube/TikTok/Twitch) | SocialBlade | NUMERIC | #97 ✅ |
+| Estadísticas fútbol | FBref / Transfermarkt | NUMERIC + BINARY | #98 |
+| Taquilla de cine | Box Office Mojo | NUMERIC | #98 |
+| Capitales y geografía | Wikipedia | BINARY | #98 |
+| Récords varios | Wikipedia / Guinness | NUMERIC | #98 |
  
 ### Pipeline de datos
  
 ```
 Spider (Scrapy)
-    │
+    │  yield QuestionItem(text, type, category, ...)
     ▼
-Item Pipeline → normalización y validación (#52)
+DeerdaysScraperPipeline (#97 ✅)
+    ├── Validación de calidad mínima
+    ├── Deduplicación por SHA-256(text) → campo text_hash en questions
+    ├── INSERT questions + question_options
+    └── UPDATE spider_runs (questionsInserted, errors, finishedAt)
     │
     ▼
 PostgreSQL → tabla questions (estado: PENDING_REVIEW)
@@ -382,13 +386,17 @@ PostgreSQL → tabla questions (estado: PENDING_REVIEW)
 Moderador revisa → estado: ACTIVE
 ```
  
-### Endpoints de gestión (solo ADMIN)
+> Ver documentación detallada del pipeline en [`docs/scraping-pipeline.md`](scraping-pipeline.md).
  
-| Método | Ruta | Descripción | Issues |
-|--------|------|-------------|--------|
-| `GET` | `/api/admin/spiders` | Lista de spiders y último estado | #51 |
-| `POST` | `/api/admin/spiders/:id/run` | Lanzar spider manualmente | #51 |
-| `GET` | `/api/admin/spiders/:id/runs` | Historial de ejecuciones | #51 |
+### Endpoints de gestión (solo ADMIN)
+
+> Implementados en #97. El identificador de ruta es el **nombre** del spider, no su UUID.
+ 
+| Método | Ruta | Descripción | Issue |
+|--------|------|-------------|-------|
+| `GET` | `/api/admin/spiders` | Lista de spiders con estado actual y último run | #97 ✅ |
+| `POST` | `/api/admin/spiders/{name}/run` | Lanza el spider por nombre. 202 con el `SpiderRun` creado. 404 si no existe, 409 si ya está en ejecución | #97 ✅ |
+| `GET` | `/api/admin/spiders/{name}/runs` | Historial de runs del spider ordenados por fecha descendente | #97 ✅ |
  
 ---
  

--- a/docs/scraping-pipeline.md
+++ b/docs/scraping-pipeline.md
@@ -1,0 +1,207 @@
+# Pipeline de Scraping — Scrapy → PostgreSQL
+
+> Documentación de la integración entre el scraper Scrapy y la base de datos PostgreSQL implementada en la issue #97.
+> Cubre: arquitectura del pipeline, contrato `QuestionItem`, deduplicación, endpoints de gestión y cómo añadir un spider nuevo.
+
+---
+
+## Visión general
+
+```
+Spider (Scrapy)
+    │  yield QuestionItem(...)
+    ▼
+DeerdaysScraperPipeline
+    ├── Valida calidad mínima
+    ├── Deduplicación por SHA-256 del texto
+    ├── INSERT en questions + question_options
+    └── UPDATE spider_runs (questionsInserted, errors, finishedAt)
+
+Backend (Spring Boot)
+    ├── POST /api/admin/spiders/{name}/run  →  ProcessBuilder("scrapy crawl {name}")
+    └── GET  /api/admin/spiders/{name}/runs →  historial de ejecuciones
+```
+
+Las preguntas insertadas quedan en `status = PENDING_REVIEW`. Un moderador las activa desde el panel de administración (issue #81).
+
+---
+
+## Contrato QuestionItem
+
+`scraper/versus_scraper/items.py`
+
+| Campo | Tipo Python | Obligatorio | Descripción |
+|---|---|---|---|
+| `text` | `str` | ✅ | Texto completo de la pregunta. Base del hash de deduplicación. |
+| `type` | `str` | ✅ | `"BINARY"` o `"NUMERIC"` |
+| `category` | `str` | ✅ | Categoría libre: `"RRSS"`, `"FOOTBALL"`, `"GEO"`, etc. |
+| `source_url` | `str` | — | URL de origen |
+| `correct_value` | `float` | Si `NUMERIC` | Valor numérico correcto |
+| `unit` | `str` | Si `NUMERIC` | Unidad legible: `"suscriptores"`, `"goles"`, `"km"`, etc. |
+| `tolerance_percent` | `float` | — | Margen de error (%). Default `5`. |
+| `options` | `list[dict]` | Si `BINARY` | Lista de `{"text": str, "is_correct": bool}`. Al menos una opción debe ser correcta. |
+
+### Ejemplo NUMERIC
+
+```python
+yield QuestionItem(
+    text="¿Cuántos suscriptores tiene Ibai en YouTube?",
+    type="NUMERIC",
+    category="RRSS",
+    source_url=response.url,
+    correct_value=12_500_000,
+    unit="suscriptores",
+    tolerance_percent=10,
+)
+```
+
+### Ejemplo BINARY
+
+```python
+yield QuestionItem(
+    text="¿El Real Madrid ganó la Champions de 2022?",
+    type="BINARY",
+    category="FOOTBALL",
+    source_url=response.url,
+    options=[
+        {"text": "Sí", "is_correct": True},
+        {"text": "No", "is_correct": False},
+    ],
+)
+```
+
+---
+
+## Pipeline — `DeerdaysScraperPipeline`
+
+`scraper/versus_scraper/pipelines.py`
+
+### Ciclo de vida
+
+| Método | Cuándo se llama | Qué hace |
+|---|---|---|
+| `open_spider` | Al arrancar el spider | Abre conexión psycopg2, busca el `spider_id` por nombre, crea entrada en `spider_runs`, marca `spiders.status = RUNNING` |
+| `process_item` | Por cada item yielded | Valida, deduplica, inserta en `questions` + `question_options` |
+| `close_spider` | Al terminar el spider | Actualiza `spider_runs` con `finishedAt`, `questionsInserted`, `errors`; marca `spiders.status = IDLE` |
+
+### Deduplicación
+
+Antes de insertar, se calcula `SHA-256(text)` y se comprueba en `questions.text_hash`. Si ya existe, el item se descarta silenciosamente (no cuenta como error). Esto garantiza idempotencia: ejecutar el mismo spider dos veces no duplica preguntas.
+
+### Validación de calidad mínima
+
+| Tipo | Condición de rechazo |
+|---|---|
+| `NUMERIC` | `correct_value` es `None` o `≤ 0` |
+| `BINARY` | Ninguna opción tiene `is_correct=True` |
+
+Los items rechazados incrementan el contador `errors` del run.
+
+### Items que no son QuestionItem
+
+Los items de otro tipo (p. ej. `SocialMediaCreatorItem`) se devuelven sin tocar. El pipeline no los procesa.
+
+---
+
+## Variables de entorno
+
+Configurables en `scraper/versus_scraper/settings.py` y sobreescribibles desde el entorno Docker:
+
+| Variable | Default | Descripción |
+|---|---|---|
+| `DB_HOST` | `localhost` | Host de PostgreSQL |
+| `DB_PORT` | `5432` | Puerto |
+| `DB_NAME` | `versus` | Nombre de la base de datos |
+| `DB_USER` | `versus` | Usuario |
+| `DB_PASSWORD` | `versus` | Contraseña |
+
+---
+
+## Endpoints de gestión (solo ADMIN)
+
+> Contrato actualizado respecto al borrador inicial: se usa `{name}` (nombre del spider) en lugar de `{id}`.
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| `GET` | `/api/admin/spiders` | Lista todos los spiders con estado actual y datos del último run |
+| `POST` | `/api/admin/spiders/{name}/run` | Lanza el spider por nombre. Devuelve 202 con el `SpiderRun` creado. 404 si no existe, 409 si ya está en ejecución |
+| `GET` | `/api/admin/spiders/{name}/runs` | Historial de runs del spider ordenados por fecha descendente |
+
+### Respuesta `SpiderResponse`
+
+```json
+{
+  "id": "uuid",
+  "name": "rrss",
+  "targetUrl": "https://socialblade.com/...",
+  "status": "IDLE",
+  "lastRunAt": "2026-05-07T10:00:00Z",
+  "lastRun": {
+    "id": "uuid",
+    "startedAt": "2026-05-07T10:00:00Z",
+    "finishedAt": "2026-05-07T10:05:00Z",
+    "questionsInserted": 42,
+    "errors": 3
+  }
+}
+```
+
+`lastRun` es `null` si el spider nunca ha sido ejecutado.
+
+### Respuesta `SpiderRunResponse`
+
+```json
+{
+  "id": "uuid",
+  "startedAt": "2026-05-07T10:00:00Z",
+  "finishedAt": "2026-05-07T10:05:00Z",
+  "questionsInserted": 42,
+  "errors": 3
+}
+```
+
+`finishedAt` es `null` mientras el proceso sigue activo.
+
+---
+
+## Cómo lanza el backend el proceso Scrapy
+
+`SpiderService.triggerRun(name)` actualiza el estado a `RUNNING`, crea el `SpiderRun` y llama a `launchProcess` en un hilo separado (`@Async`). Así el endpoint devuelve 202 inmediatamente.
+
+`launchProcess` usa `ProcessBuilder`:
+
+```
+scrapy crawl {name}
+```
+
+ejecutado en el directorio configurado por la propiedad `scraper.working-dir` (por defecto `../scraper`, sobreescribible con la variable de entorno `SCRAPER_DIR`).
+
+Al terminar el proceso:
+- Exit code `0` → `Spider.status = IDLE`
+- Cualquier otro exit code o `IOException` → `Spider.status = FAILED`
+
+En ambos casos `SpiderRun.finishedAt` se establece en el bloque `finally`.
+
+> **Importante:** `@Async` requiere que `launchProcess` sea invocado desde fuera del bean (a través del proxy de Spring). Si en el futuro se refactoriza el servicio, asegurarse de que esta llamada no se produce por auto-invocación.
+
+---
+
+## Cómo añadir un spider nuevo (checklist para issue #98)
+
+1. Crear el spider en `scraper/versus_scraper/spiders/<nombre>_spider.py` siguiendo el patrón de `rrss_spider.py`.
+2. Hacer que cada fila yielde un `QuestionItem` con todos los campos obligatorios según el tipo (`NUMERIC` o `BINARY`).
+3. Insertar una fila en la tabla `spiders` con `name = '<nombre>'` y `status = 'IDLE'` (puede hacerse en el seed de dev).
+4. Verificar que el pipeline inserta correctamente: `scrapy crawl <nombre>` desde el directorio `scraper/`.
+5. Disparar desde el panel de admin: `POST /api/admin/spiders/<nombre>/run`.
+
+El pipeline ya maneja la conexión a BD, la deduplicación y el registro del run — el spider solo tiene que centrarse en extraer datos y mapearlos a `QuestionItem`.
+
+---
+
+## Cambios al esquema DB introducidos por esta issue
+
+| Tabla | Cambio | Motivo |
+|---|---|---|
+| `questions` | Nuevo campo `text_hash VARCHAR(64) UNIQUE` | Deduplicación idempotente por hash SHA-256 del texto |
+
+Ver esquema actualizado en [`docs/bd-scheme.md`](bd-scheme.md).

--- a/scraper/versus_scraper/items.py
+++ b/scraper/versus_scraper/items.py
@@ -1,8 +1,3 @@
-# Define here the models for your scraped items
-#
-# See documentation in:
-# https://docs.scrapy.org/en/latest/topics/items.html
-
 import scrapy
 
 
@@ -11,3 +6,17 @@ class SocialMediaCreatorItem(scrapy.Item):
     image = scrapy.Field()
     subscribers = scrapy.Field()
     platform = scrapy.Field()
+
+
+class QuestionItem(scrapy.Item):
+    """Normalized question ready to be inserted into the `questions` table."""
+    text = scrapy.Field()           # question text (used for dedup hash)
+    type = scrapy.Field()           # 'BINARY' or 'NUMERIC'
+    category = scrapy.Field()       # e.g. 'RRSS', 'FOOTBALL'
+    source_url = scrapy.Field()
+    # NUMERIC-specific
+    correct_value = scrapy.Field()  # numeric answer
+    unit = scrapy.Field()           # e.g. 'subscribers', 'goals'
+    tolerance_percent = scrapy.Field()
+    # BINARY-specific
+    options = scrapy.Field()        # list of {'text': str, 'is_correct': bool}

--- a/scraper/versus_scraper/pipelines.py
+++ b/scraper/versus_scraper/pipelines.py
@@ -1,13 +1,173 @@
-# Define your item pipelines here
-#
-# Don't forget to add your pipeline to the ITEM_PIPELINES setting
-# See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
+import hashlib
+import logging
+import os
+from datetime import datetime, timezone
 
-
-# useful for handling different item types with a single interface
+import psycopg2
 from itemadapter import ItemAdapter
+
+from versus_scraper.items import QuestionItem
+
+logger = logging.getLogger(__name__)
 
 
 class DeerdaysScraperPipeline:
+    """Inserts scraped QuestionItems into PostgreSQL.
+
+    Non-QuestionItem items are passed through unchanged so other pipelines
+    (e.g. JSON export) can still consume them.
+    """
+
+    def open_spider(self, spider):
+        self.conn = psycopg2.connect(
+            host=os.getenv("DB_HOST", "localhost"),
+            port=int(os.getenv("DB_PORT", "5432")),
+            dbname=os.getenv("DB_NAME", "versus"),
+            user=os.getenv("DB_USER", "versus"),
+            password=os.getenv("DB_PASSWORD", "versus"),
+        )
+        self.conn.autocommit = False
+        self.cursor = self.conn.cursor()
+
+        self.questions_inserted = 0
+        self.errors = 0
+        self.run_id = None
+        self.spider_id = self._resolve_spider_id(spider.name)
+
+        if self.spider_id:
+            self._start_run()
+
+    def close_spider(self, spider):
+        try:
+            if self.run_id:
+                self._finish_run()
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            logger.exception("Error finalizing spider run")
+        finally:
+            self.cursor.close()
+            self.conn.close()
+
     def process_item(self, item, spider):
+        if not isinstance(item, QuestionItem):
+            return item
+
+        adapter = ItemAdapter(item)
+        text = adapter.get("text", "").strip()
+        if not text:
+            self.errors += 1
+            return item
+
+        question_type = adapter.get("type", "BINARY")
+        if not self._is_valid(adapter, question_type):
+            self.errors += 1
+            return item
+
+        text_hash = hashlib.sha256(text.encode()).hexdigest()
+
+        try:
+            question_id = self._upsert_question(adapter, text, text_hash, question_type)
+            if question_id and question_type == "BINARY":
+                self._upsert_options(question_id, adapter.get("options", []))
+            if question_id:
+                self.questions_inserted += 1
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            self.errors += 1
+            logger.exception("Error inserting question: %s", text[:60])
+
         return item
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _is_valid(self, adapter, question_type):
+        if question_type == "NUMERIC":
+            val = adapter.get("correct_value")
+            return val is not None
+        if question_type == "BINARY":
+            options = adapter.get("options") or []
+            return any(o.get("is_correct") for o in options)
+        return False
+
+    def _upsert_question(self, adapter, text, text_hash, question_type):
+        """Insert question; skip if the hash already exists. Returns the UUID or None."""
+        self.cursor.execute(
+            "SELECT id FROM questions WHERE text_hash = %s", (text_hash,)
+        )
+        row = self.cursor.fetchone()
+        if row:
+            return None  # duplicate — skip
+
+        self.cursor.execute(
+            """
+            INSERT INTO questions
+                (text, type, category, source_url, scraped_at, status,
+                 correct_value, unit, tolerance_percent, text_hash)
+            VALUES (%s, %s, %s, %s, %s, 'PENDING_REVIEW', %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                text,
+                question_type,
+                adapter.get("category"),
+                adapter.get("source_url"),
+                datetime.now(timezone.utc),
+                adapter.get("correct_value"),
+                adapter.get("unit"),
+                adapter.get("tolerance_percent", 5),
+                text_hash,
+            ),
+        )
+        return self.cursor.fetchone()[0]
+
+    def _upsert_options(self, question_id, options):
+        for opt in options:
+            self.cursor.execute(
+                "INSERT INTO question_options (question_id, text, is_correct) VALUES (%s, %s, %s)",
+                (question_id, opt["text"], opt.get("is_correct", False)),
+            )
+
+    def _resolve_spider_id(self, spider_name):
+        try:
+            self.cursor.execute(
+                "SELECT id FROM spiders WHERE name = %s", (spider_name,)
+            )
+            row = self.cursor.fetchone()
+            if row:
+                self.cursor.execute(
+                    "UPDATE spiders SET status = 'RUNNING', last_run_at = %s WHERE id = %s",
+                    (datetime.now(timezone.utc), row[0]),
+                )
+                self.conn.commit()
+                return row[0]
+        except Exception:
+            logger.warning("Could not resolve spider_id for '%s' — run will not be tracked", spider_name)
+        return None
+
+    def _start_run(self):
+        self.cursor.execute(
+            """
+            INSERT INTO spider_runs (spider_id, started_at, questions_inserted, errors)
+            VALUES (%s, %s, 0, 0)
+            RETURNING id
+            """,
+            (self.spider_id, datetime.now(timezone.utc)),
+        )
+        self.run_id = self.cursor.fetchone()[0]
+        self.conn.commit()
+
+    def _finish_run(self):
+        self.cursor.execute(
+            """
+            UPDATE spider_runs
+            SET finished_at = %s, questions_inserted = %s, errors = %s
+            WHERE id = %s
+            """,
+            (datetime.now(timezone.utc), self.questions_inserted, self.errors, self.run_id),
+        )
+        self.cursor.execute(
+            "UPDATE spiders SET status = 'IDLE' WHERE id = %s",
+            (self.spider_id,),
+        )

--- a/scraper/versus_scraper/settings.py
+++ b/scraper/versus_scraper/settings.py
@@ -62,9 +62,18 @@ ROBOTSTXT_OBEY = False
 
 # Configure item pipelines
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
-#ITEM_PIPELINES = {
-#    "deerdays_scraper.pipelines.DeerdaysScraperPipeline": 300,
-#}
+ITEM_PIPELINES = {
+    "versus_scraper.pipelines.DeerdaysScraperPipeline": 300,
+}
+
+# PostgreSQL connection — override via environment variables in Docker
+import os  # noqa: E402
+
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = int(os.getenv("DB_PORT", "5432"))
+DB_NAME = os.getenv("DB_NAME", "versus")
+DB_USER = os.getenv("DB_USER", "versus")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "versus")
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html


### PR DESCRIPTION
## Descripción

Cierra #97. Implementa el pipeline completo de ingesta Scrapy → PostgreSQL y los endpoints REST de gestión de spiders desde el panel de administración.

Esta issue completaba el trabajo pendiente del Sprint 4: los endpoints de spiders existían como stubs, pero el proceso real de scraping no llegaba a la base de datos.

## Cambios

### Scrapy
- **`QuestionItem`** — nuevo item normalizado con todos los campos del modelo `Question` (`text`, `type`, `category`, `correct_value`, `unit`, `tolerance_percent`, `options`). Es el contrato que los spiders de la issue #98 deberán usar.
- **`DeerdaysScraperPipeline`** — implementación completa de `process_item`: conexión a PostgreSQL vía `psycopg2`, validación de calidad mínima, deduplicación por `SHA-256(text)` (evita duplicados si el spider se ejecuta varias veces), inserción en `questions` + `question_options`, y registro del run en `spider_runs` con `questionsInserted`, `errors` y `finishedAt`.
- **`settings.py`** — pipeline habilitada, variables de entorno de BD (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`).

### Backend
- **`SpiderService`** — `listSpiders`, `triggerRun`, `getRunHistory`. El lanzamiento del proceso Scrapy es asíncrono (`@Async` + `ProcessBuilder`): el endpoint devuelve 202 inmediatamente y el estado del spider se actualiza al terminar el proceso.
- **`SpiderController`** — `GET /api/admin/spiders`, `POST /api/admin/spiders/{name}/run`, `GET /api/admin/spiders/{name}/runs`. El identificador de ruta es el nombre del spider, no su UUID.
- **`SecurityConfig`** — `/api/admin/**` restringido a rol `ADMIN`.
- **`ApiApplication`** — `@EnableAsync` para el lanzamiento en background.
- **`Question`** — campo `text_hash VARCHAR(64) UNIQUE` para la deduplicación del pipeline.
- **`SpiderRepository` / `SpiderRunRepository`** — queries derivadas necesarias.

### Tests
- **`SpiderServiceTest`** — 33 tests unitarios con Mockito: `listSpiders` (6), `triggerRun` (13), `getRunHistory` (6), `launchProcess` (8). Cubre camino feliz, errores de negocio (NOT_FOUND, CONFLICT), comportamiento del bloque `finally` (finishedAt siempre se establece), y los estados IDLE/FAILED según el exit code del proceso usando `mockConstruction(ProcessBuilder.class)`.

### Documentación
- **`docs/scraping-pipeline.md`** — nuevo documento de referencia: arquitectura, contrato `QuestionItem`, ciclo de vida del pipeline, deduplicación, variables de entorno, shapes de respuesta de los endpoints, y checklist para añadir un spider nuevo (guía directa para #98).
- **`docs/guia-de-coordinación-técnica.md`** — módulo SCRAPING actualizado con los endpoints reales (`{name}` en lugar de `:id`), flujo del pipeline y referencias cruzadas.
- **`docs/bd-scheme.md`** — campo `text_hash` añadido al diagrama ER y a la tabla de índices.

## Notas

- Los spiders concretos (fútbol, cine, geografía, récords) son trabajo de #98. El pipeline y los endpoints están listos para recibirlos.
- El spider `rrss` existente no ha sido modificado; su integración con `QuestionItem` forma parte de #98.
- `scraper.working-dir` es configurable vía la variable de entorno `SCRAPER_DIR` para compatibilidad Docker.