### PR TITLE
feat: infraestructura de email #120

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,26 @@ R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_BUCKET=versus-media
 R2_PUBLIC_BASE_URL=
+
+# ── Mail / SMTP ────────────────────────────────
+# Dev: usa MailHog (SMTP_HOST=mailhog, SMTP_PORT=1025) — sin credenciales
+# Prod: proveedor real (Resend, SendGrid, SES, etc.)
+# MailHog (mock local, por defecto):
+SMTP_HOST=mailhog
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
+SMTP_AUTH=false
+SMTP_STARTTLS=false
+MAIL_FROM=noreply@versus-dev.local
+MAIL_FROM_NAME=Versus Dev
+FRONTEND_BASE_URL=http://localhost:4200
+
+# Gmail real (sustituye los valores anteriores en tu .env):
+# SMTP_HOST=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_USER=tu-cuenta@gmail.com
+# SMTP_PASS=xxxx xxxx xxxx xxxx   ← App Password de 16 chars
+# SMTP_AUTH=true
+# SMTP_STARTTLS=true
+# MAIL_FROM=tu-cuenta@gmail.com   ← debe coincidir con SMTP_USER en Gmail

--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,21 @@
-# .env.example — Copia este archivo a .env y rellena los valores
-# El .env real NO debe commitearse (está en .gitignore)
+# .env.example - Copy this file to .env and fill the values.
+# The real .env file must not be committed.
 
-# ── PostgreSQL ────────────────────────────────
+# PostgreSQL
 POSTGRES_DB=appdb
 POSTGRES_USER=appuser
 POSTGRES_PASSWORD=changeme
 
-# ── pgAdmin (solo dev) ────────────────────────
+# pgAdmin (dev only)
 PGADMIN_EMAIL=admin@admin.com
 PGADMIN_PASSWORD=admin
 
-# ── Spring Boot ───────────────────────────────
-# DDL_AUTO=update      (dev)
-# DDL_AUTO=validate    (prod)
+# Spring Boot
+# DDL_AUTO=update   (dev)
+# DDL_AUTO=validate (prod)
 DDL_AUTO=update
 
-# Storage / Multimedia
+# Storage / Media
 # local (dev/test) or r2 (Cloudflare R2)
 STORAGE_PROVIDER=local
 STORAGE_LOCAL_ROOT=target/local-storage
@@ -32,10 +32,8 @@ R2_SECRET_ACCESS_KEY=
 R2_BUCKET=versus-media
 R2_PUBLIC_BASE_URL=
 
-# ── Mail / SMTP ────────────────────────────────
-# Dev: usa MailHog (SMTP_HOST=mailhog, SMTP_PORT=1025) — sin credenciales
-# Prod: proveedor real (Resend, SendGrid, SES, etc.)
-# MailHog (mock local, por defecto):
+# Mail / SMTP
+# Default dev provider: MailHog. Open http://localhost:8025 to inspect emails.
 SMTP_HOST=mailhog
 SMTP_PORT=1025
 SMTP_USER=
@@ -44,13 +42,28 @@ SMTP_AUTH=false
 SMTP_STARTTLS=false
 MAIL_FROM=noreply@versus-dev.local
 MAIL_FROM_NAME=Versus Dev
+VERSUS_EMAIL_ENABLED=false
 FRONTEND_BASE_URL=http://localhost:4200
 
-# Gmail real (sustituye los valores anteriores en tu .env):
+# Gmail SMTP example. Replace the MailHog values above in your local .env.
 # SMTP_HOST=smtp.gmail.com
 # SMTP_PORT=587
-# SMTP_USER=tu-cuenta@gmail.com
-# SMTP_PASS=xxxx xxxx xxxx xxxx   ← App Password de 16 chars
+# SMTP_USER=your-account@gmail.com
+# SMTP_PASS=xxxx xxxx xxxx xxxx
 # SMTP_AUTH=true
 # SMTP_STARTTLS=true
-# MAIL_FROM=tu-cuenta@gmail.com   ← debe coincidir con SMTP_USER en Gmail
+# MAIL_FROM=your-account@gmail.com
+# MAIL_FROM_NAME=Versus
+# VERSUS_EMAIL_ENABLED=true
+
+# Resend SMTP example. Replace the MailHog values above in your local .env.
+# Official Resend SMTP docs: https://resend.com/docs/send-with-smtp
+# SMTP_HOST=smtp.resend.com
+# SMTP_PORT=587
+# SMTP_USER=resend
+# SMTP_PASS=re_xxxxxxxxxxxxxxxxxxxxxxxxx
+# SMTP_AUTH=true
+# SMTP_STARTTLS=true
+# MAIL_FROM=onboarding@your-verified-domain.com
+# MAIL_FROM_NAME=Versus
+# VERSUS_EMAIL_ENABLED=true

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -50,6 +50,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>

--- a/backend/src/main/java/com/versus/api/auth/AuthController.java
+++ b/backend/src/main/java/com/versus/api/auth/AuthController.java
@@ -2,6 +2,9 @@ package com.versus.api.auth;
 
 import com.versus.api.auth.dto.AuthResponse;
 import com.versus.api.auth.dto.LoginRequest;
+import com.versus.api.auth.dto.MessageResponse;
+import com.versus.api.auth.dto.PasswordResetConfirmRequest;
+import com.versus.api.auth.dto.PasswordResetRequest;
 import com.versus.api.auth.dto.RefreshRequest;
 import com.versus.api.auth.dto.RegisterRequest;
 import com.versus.api.common.dto.ErrorResponse;
@@ -16,7 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Auth", description = "Registration, login, token refresh and logout")
+@Tag(name = "Auth", description = "Registration, login, token refresh, logout, email verification and password reset")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -25,23 +28,52 @@ public class AuthController {
     private final AuthService authService;
 
     @Operation(summary = "Register a new player account", responses = {
-            @ApiResponse(responseCode = "201", description = "Account created"),
+            @ApiResponse(responseCode = "201", description = "Account created — verification email sent"),
             @ApiResponse(responseCode = "400", description = "Validation error", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "409", description = "Email or username already taken", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
-    public AuthResponse register(@Valid @RequestBody RegisterRequest req) {
+    public MessageResponse register(@Valid @RequestBody RegisterRequest req) {
         return authService.register(req);
     }
 
     @Operation(summary = "Log in and obtain JWT tokens", responses = {
             @ApiResponse(responseCode = "200", description = "Authenticated"),
-            @ApiResponse(responseCode = "401", description = "Invalid credentials", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "Invalid credentials", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Email not verified", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/login")
     public AuthResponse login(@Valid @RequestBody LoginRequest req) {
         return authService.login(req);
+    }
+
+    @Operation(summary = "Verify email address with token from email link", responses = {
+            @ApiResponse(responseCode = "200", description = "Account verified"),
+            @ApiResponse(responseCode = "400", description = "Invalid token", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "410", description = "Token expired", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/verify")
+    public MessageResponse verifyEmail(@RequestParam String token) {
+        return authService.verifyEmail(token);
+    }
+
+    @Operation(summary = "Request a password reset email", responses = {
+            @ApiResponse(responseCode = "200", description = "Email sent if address is registered")
+    })
+    @PostMapping("/password-reset/request")
+    public MessageResponse requestPasswordReset(@Valid @RequestBody PasswordResetRequest req) {
+        return authService.requestPasswordReset(req);
+    }
+
+    @Operation(summary = "Confirm password reset with token and new password", responses = {
+            @ApiResponse(responseCode = "200", description = "Password updated"),
+            @ApiResponse(responseCode = "400", description = "Invalid token or validation error", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "410", description = "Token expired", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/password-reset/confirm")
+    public MessageResponse confirmPasswordReset(@Valid @RequestBody PasswordResetConfirmRequest req) {
+        return authService.confirmPasswordReset(req);
     }
 
     @Operation(summary = "Exchange a refresh token for a new token pair", responses = {

--- a/backend/src/main/java/com/versus/api/auth/AuthService.java
+++ b/backend/src/main/java/com/versus/api/auth/AuthService.java
@@ -3,6 +3,9 @@ package com.versus.api.auth;
 import com.versus.api.auth.domain.RefreshToken;
 import com.versus.api.auth.dto.AuthResponse;
 import com.versus.api.auth.dto.LoginRequest;
+import com.versus.api.auth.dto.MessageResponse;
+import com.versus.api.auth.dto.PasswordResetConfirmRequest;
+import com.versus.api.auth.dto.PasswordResetRequest;
 import com.versus.api.auth.dto.RegisterRequest;
 import com.versus.api.auth.repo.RefreshTokenRepository;
 import com.versus.api.common.exception.ApiException;
@@ -11,12 +14,17 @@ import com.versus.api.users.UserStatus;
 import com.versus.api.users.domain.User;
 import com.versus.api.users.repo.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Base64;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -25,15 +33,23 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokens;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwt;
+    private final EmailService emailService;
+
+    @Value("${versus.auth.verification-token-expiry:86400}")
+    private long verificationTokenExpiry;
+
+    @Value("${versus.auth.reset-token-expiry:900}")
+    private long resetTokenExpiry;
 
     @Transactional
-    public AuthResponse register(RegisterRequest req) {
+    public MessageResponse register(RegisterRequest req) {
         if (users.existsByEmail(req.email())) {
             throw ApiException.conflict("Email already registered");
         }
         if (users.existsByUsername(req.username())) {
             throw ApiException.conflict("Username already taken");
         }
+        String token = generateSecureToken();
         User user = User.builder()
                 .username(req.username())
                 .email(req.email())
@@ -41,9 +57,14 @@ public class AuthService {
                 .role(Role.PLAYER)
                 .status(UserStatus.ACTIVE)
                 .isActive(true)
+                .enabled(false)
+                .verificationToken(token)
+                .verificationTokenExpiry(Instant.now().plusSeconds(verificationTokenExpiry))
                 .build();
         users.save(user);
-        return issueTokens(user);
+        log.info("Dispatching verification email to {}", user.getEmail());
+        emailService.sendVerificationEmail(user.getEmail(), user.getUsername(), token);
+        return new MessageResponse("Registro completado. Por favor, verifica tu correo electrónico para activar tu cuenta.");
     }
 
     @Transactional
@@ -56,10 +77,59 @@ public class AuthService {
         if (UserStatus.DELETED.equals(user.getStatus())) {
             throw ApiException.unauthorized("Account disabled");
         }
+        if (Boolean.FALSE.equals(user.getEnabled())) {
+            throw ApiException.emailNotVerified("Email not verified. Please check your inbox.");
+        }
         if (!passwordEncoder.matches(req.password(), user.getPasswordHash())) {
             throw ApiException.unauthorized("Invalid credentials");
         }
         return issueTokens(user);
+    }
+
+    @Transactional
+    public MessageResponse verifyEmail(String token) {
+        User user = users.findByVerificationToken(token)
+                .orElseThrow(() -> ApiException.tokenInvalid("Verification token not found"));
+        if (Boolean.TRUE.equals(user.getEnabled())) {
+            return new MessageResponse("La cuenta ya estaba verificada.");
+        }
+        if (user.getVerificationTokenExpiry() == null ||
+                user.getVerificationTokenExpiry().isBefore(Instant.now())) {
+            throw ApiException.tokenExpired("Verification token has expired. Please register again or request a new verification email.");
+        }
+        user.setEnabled(true);
+        user.setVerificationToken(null);
+        user.setVerificationTokenExpiry(null);
+        users.save(user);
+        return new MessageResponse("Cuenta verificada correctamente. Ya puedes iniciar sesión.");
+    }
+
+    @Transactional
+    public MessageResponse requestPasswordReset(PasswordResetRequest req) {
+        users.findByEmail(req.email()).ifPresent(user -> {
+            String token = generateSecureToken();
+            user.setPasswordResetToken(token);
+            user.setPasswordResetTokenExpiry(Instant.now().plusSeconds(resetTokenExpiry));
+            users.save(user);
+            emailService.sendPasswordResetEmail(user.getEmail(), user.getUsername(), token);
+        });
+        // Siempre devuelve el mismo mensaje para no revelar si el email existe
+        return new MessageResponse("Si el correo está registrado, recibirás un enlace para restablecer tu contraseña.");
+    }
+
+    @Transactional
+    public MessageResponse confirmPasswordReset(PasswordResetConfirmRequest req) {
+        User user = users.findByPasswordResetToken(req.token())
+                .orElseThrow(() -> ApiException.tokenInvalid("Password reset token not found"));
+        if (user.getPasswordResetTokenExpiry() == null ||
+                user.getPasswordResetTokenExpiry().isBefore(Instant.now())) {
+            throw ApiException.tokenExpired("Password reset token has expired. Please request a new one.");
+        }
+        user.setPasswordHash(passwordEncoder.encode(req.newPassword()));
+        user.setPasswordResetToken(null);
+        user.setPasswordResetTokenExpiry(null);
+        users.save(user);
+        return new MessageResponse("Contraseña actualizada correctamente. Ya puedes iniciar sesión.");
     }
 
     @Transactional
@@ -107,5 +177,11 @@ public class AuthService {
                         user.getUsername(),
                         user.getRole().name(),
                         user.getAvatarUrl()));
+    }
+
+    private String generateSecureToken() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 }

--- a/backend/src/main/java/com/versus/api/auth/EmailService.java
+++ b/backend/src/main/java/com/versus/api/auth/EmailService.java
@@ -1,0 +1,75 @@
+package com.versus.api.auth;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+
+    @Value("${versus.mail.from}")
+    private String from;
+
+    @Value("${versus.mail.from-name}")
+    private String fromName;
+
+    @Value("${versus.frontend.base-url}")
+    private String frontendBaseUrl;
+
+    @Async
+    public void sendVerificationEmail(String toEmail, String username, String token) {
+        String verifyUrl = frontendBaseUrl + "/verify-email?token=" + token;
+        Context ctx = new Context(Locale.forLanguageTag("es"));
+        ctx.setVariables(Map.of(
+                "username", username,
+                "verifyUrl", verifyUrl,
+                "frontendBaseUrl", frontendBaseUrl
+        ));
+        send(toEmail, "Verifica tu cuenta en Versus", "email/verification", ctx);
+    }
+
+    @Async
+    public void sendPasswordResetEmail(String toEmail, String username, String token) {
+        String resetUrl = frontendBaseUrl + "/reset-password?token=" + token;
+        Context ctx = new Context(Locale.forLanguageTag("es"));
+        ctx.setVariables(Map.of(
+                "username", username,
+                "resetUrl", resetUrl,
+                "frontendBaseUrl", frontendBaseUrl
+        ));
+        send(toEmail, "Recupera tu contraseña en Versus", "email/password-reset", ctx);
+    }
+
+    private void send(String to, String subject, String template, Context ctx) {
+        try {
+            String html = templateEngine.process(template, ctx);
+            MimeMessage msg = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(
+                    msg, MimeMessageHelper.MULTIPART_MODE_MIXED_RELATED,
+                    StandardCharsets.UTF_8.name());
+            helper.setFrom(from, fromName);
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(html, true);
+            mailSender.send(msg);
+        } catch (Exception e) {
+            log.error("Failed to send email to {}: {}", to, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/versus/api/auth/dto/MessageResponse.java
+++ b/backend/src/main/java/com/versus/api/auth/dto/MessageResponse.java
@@ -1,0 +1,3 @@
+package com.versus.api.auth.dto;
+
+public record MessageResponse(String message) {}

--- a/backend/src/main/java/com/versus/api/auth/dto/PasswordResetConfirmRequest.java
+++ b/backend/src/main/java/com/versus/api/auth/dto/PasswordResetConfirmRequest.java
@@ -1,0 +1,9 @@
+package com.versus.api.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PasswordResetConfirmRequest(
+        @NotBlank String token,
+        @NotBlank @Size(min = 8, max = 100) String newPassword
+) {}

--- a/backend/src/main/java/com/versus/api/auth/dto/PasswordResetRequest.java
+++ b/backend/src/main/java/com/versus/api/auth/dto/PasswordResetRequest.java
@@ -1,0 +1,8 @@
+package com.versus.api.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetRequest(
+        @NotBlank @Email String email
+) {}

--- a/backend/src/main/java/com/versus/api/common/exception/ApiException.java
+++ b/backend/src/main/java/com/versus/api/common/exception/ApiException.java
@@ -30,4 +30,16 @@ public class ApiException extends RuntimeException {
     public static ApiException validation(String message) {
         return new ApiException(ErrorCode.VALIDATION_ERROR, message);
     }
+
+    public static ApiException tokenInvalid(String message) {
+        return new ApiException(ErrorCode.TOKEN_INVALID, message);
+    }
+
+    public static ApiException tokenExpired(String message) {
+        return new ApiException(ErrorCode.TOKEN_EXPIRED, message);
+    }
+
+    public static ApiException emailNotVerified(String message) {
+        return new ApiException(ErrorCode.EMAIL_NOT_VERIFIED, message);
+    }
 }

--- a/backend/src/main/java/com/versus/api/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/versus/api/common/exception/ErrorCode.java
@@ -8,6 +8,9 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND),
     CONFLICT(HttpStatus.CONFLICT),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST),
+    TOKEN_INVALID(HttpStatus.BAD_REQUEST),
+    TOKEN_EXPIRED(HttpStatus.GONE),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final HttpStatus status;

--- a/backend/src/main/java/com/versus/api/config/AsyncConfig.java
+++ b/backend/src/main/java/com/versus/api/config/AsyncConfig.java
@@ -1,0 +1,35 @@
+package com.versus.api.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Slf4j
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "taskExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("async-mail-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("[Async] Uncaught exception in {}: {}", method.getName(), ex.getMessage(), ex);
+    }
+}

--- a/backend/src/main/java/com/versus/api/config/SecurityConfig.java
+++ b/backend/src/main/java/com/versus/api/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/auth/verify").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/questions/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/media-files/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()

--- a/backend/src/main/java/com/versus/api/email/EmailSendingException.java
+++ b/backend/src/main/java/com/versus/api/email/EmailSendingException.java
@@ -1,0 +1,7 @@
+package com.versus.api.email;
+
+public class EmailSendingException extends RuntimeException {
+    public EmailSendingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/versus/api/email/EmailService.java
+++ b/backend/src/main/java/com/versus/api/email/EmailService.java
@@ -1,0 +1,81 @@
+package com.versus.api.email;
+
+import com.versus.api.email.config.EmailProperties;
+import com.versus.api.email.model.EmailRequest;
+import com.versus.api.email.template.EmailTemplateRenderer;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final EmailTemplateRenderer templateRenderer;
+    private final EmailProperties properties;
+
+    public void send(String to, String subject, String template, Map<String, Object> variables) {
+        send(EmailRequest.fromTemplate(to, subject, template, variables));
+    }
+
+    public void sendHtml(String to, String subject, String htmlBody) {
+        send(EmailRequest.fromHtml(to, subject, htmlBody));
+    }
+
+    public void send(EmailRequest request) {
+        validate(request);
+        if (!properties.enabled()) {
+            log.warn("Email delivery skipped because the infrastructure email module is disabled. to={}", request.to());
+            return;
+        }
+
+        String html = StringUtils.hasText(request.htmlBody())
+                ? request.htmlBody()
+                : templateRenderer.render(request.template(), request.variables());
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(
+                    message,
+                    MimeMessageHelper.MULTIPART_MODE_MIXED_RELATED,
+                    StandardCharsets.UTF_8.name()
+            );
+            helper.setFrom(properties.from(), properties.fromName());
+            helper.setTo(request.to());
+            helper.setSubject(request.subject());
+            helper.setText(html, true);
+            mailSender.send(message);
+            log.info("Email sent successfully to {}", request.to());
+        } catch (MessagingException | MailException ex) {
+            log.error("Email delivery failed to {}: {}", request.to(), ex.getMessage(), ex);
+            throw new EmailSendingException("Email delivery failed", ex);
+        } catch (Exception ex) {
+            log.error("Unexpected email delivery failure to {}: {}", request.to(), ex.getMessage(), ex);
+            throw new EmailSendingException("Unexpected email delivery failure", ex);
+        }
+    }
+
+    private void validate(EmailRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Email request is required");
+        }
+        if (!StringUtils.hasText(request.to())) {
+            throw new IllegalArgumentException("Email recipient is required");
+        }
+        if (!StringUtils.hasText(request.subject())) {
+            throw new IllegalArgumentException("Email subject is required");
+        }
+        if (!StringUtils.hasText(request.htmlBody()) && !StringUtils.hasText(request.template())) {
+            throw new IllegalArgumentException("Email template or HTML body is required");
+        }
+    }
+}

--- a/backend/src/main/java/com/versus/api/email/config/EmailConfiguration.java
+++ b/backend/src/main/java/com/versus/api/email/config/EmailConfiguration.java
@@ -1,0 +1,34 @@
+package com.versus.api.email.config;
+
+import com.versus.api.email.EmailService;
+import com.versus.api.email.template.ThymeleafEmailTemplateRenderer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.TemplateEngine;
+
+@Slf4j
+@Configuration
+@EnableConfigurationProperties(EmailProperties.class)
+public class EmailConfiguration {
+
+    @Bean(name = "infrastructureEmailService")
+    public EmailService infrastructureEmailService(
+            JavaMailSender mailSender,
+            EmailProperties emailProperties,
+            Environment environment,
+            TemplateEngine templateEngine
+    ) {
+        if (!emailProperties.enabled()) {
+            log.warn("Infrastructure email module is disabled. Set VERSUS_EMAIL_ENABLED=true to send emails.");
+        }
+        String smtpHost = environment.getProperty("spring.mail.host");
+        if (smtpHost == null || smtpHost.isBlank()) {
+            log.warn("SMTP host is not configured. Set SMTP_HOST before enabling email delivery.");
+        }
+        return new EmailService(mailSender, new ThymeleafEmailTemplateRenderer(templateEngine), emailProperties);
+    }
+}

--- a/backend/src/main/java/com/versus/api/email/config/EmailProperties.java
+++ b/backend/src/main/java/com/versus/api/email/config/EmailProperties.java
@@ -1,0 +1,19 @@
+package com.versus.api.email.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "versus.email")
+public record EmailProperties(
+        String from,
+        String fromName,
+        boolean enabled
+) {
+    public EmailProperties {
+        if (from == null || from.isBlank()) {
+            from = "noreply@versus-game.com";
+        }
+        if (fromName == null || fromName.isBlank()) {
+            fromName = "Versus Game";
+        }
+    }
+}

--- a/backend/src/main/java/com/versus/api/email/model/EmailRequest.java
+++ b/backend/src/main/java/com/versus/api/email/model/EmailRequest.java
@@ -1,0 +1,24 @@
+package com.versus.api.email.model;
+
+import java.util.Map;
+
+public record EmailRequest(
+        String to,
+        String subject,
+        String template,
+        String htmlBody,
+        Map<String, Object> variables
+) {
+    public static EmailRequest fromTemplate(
+            String to,
+            String subject,
+            String template,
+            Map<String, Object> variables
+    ) {
+        return new EmailRequest(to, subject, template, null, variables);
+    }
+
+    public static EmailRequest fromHtml(String to, String subject, String htmlBody) {
+        return new EmailRequest(to, subject, null, htmlBody, Map.of());
+    }
+}

--- a/backend/src/main/java/com/versus/api/email/template/EmailTemplateRenderer.java
+++ b/backend/src/main/java/com/versus/api/email/template/EmailTemplateRenderer.java
@@ -1,0 +1,7 @@
+package com.versus.api.email.template;
+
+import java.util.Map;
+
+public interface EmailTemplateRenderer {
+    String render(String template, Map<String, Object> variables);
+}

--- a/backend/src/main/java/com/versus/api/email/template/ThymeleafEmailTemplateRenderer.java
+++ b/backend/src/main/java/com/versus/api/email/template/ThymeleafEmailTemplateRenderer.java
@@ -1,0 +1,23 @@
+package com.versus.api.email.template;
+
+import lombok.RequiredArgsConstructor;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Locale;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class ThymeleafEmailTemplateRenderer implements EmailTemplateRenderer {
+
+    private final TemplateEngine templateEngine;
+
+    @Override
+    public String render(String template, Map<String, Object> variables) {
+        Context context = new Context(Locale.getDefault());
+        if (variables != null) {
+            context.setVariables(variables);
+        }
+        return templateEngine.process(template, context);
+    }
+}

--- a/backend/src/main/java/com/versus/api/users/domain/User.java
+++ b/backend/src/main/java/com/versus/api/users/domain/User.java
@@ -54,10 +54,27 @@ public class User {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
 
+    /** false hasta que el usuario verifique su correo */
+    @Column(name = "enabled", nullable = false)
+    private Boolean enabled;
+
+    @Column(name = "verification_token", length = 64)
+    private String verificationToken;
+
+    @Column(name = "verification_token_expiry")
+    private Instant verificationTokenExpiry;
+
+    @Column(name = "password_reset_token", length = 64)
+    private String passwordResetToken;
+
+    @Column(name = "password_reset_token_expiry")
+    private Instant passwordResetTokenExpiry;
+
     @PrePersist
     void onCreate() {
         if (createdAt == null) createdAt = Instant.now();
         if (isActive == null) isActive = true;
+        if (enabled == null) enabled = false;
         if (role == null) role = Role.PLAYER;
         if (status == null) status = UserStatus.ACTIVE;
         updatedAt = createdAt;

--- a/backend/src/main/java/com/versus/api/users/repo/UserRepository.java
+++ b/backend/src/main/java/com/versus/api/users/repo/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUsername(String username);
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
+    Optional<User> findByVerificationToken(String verificationToken);
+    Optional<User> findByPasswordResetToken(String passwordResetToken);
 }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -6,3 +6,15 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 
 versus.jwt.secret=${JWT_SECRET:dev-secret-change-me-please-make-this-very-long-at-least-64-bytes-aaaaaaaa}
 versus.seed.enabled=true
+
+# ── Mail (MailHog dev mock — no requiere auth ni TLS) ────────────────────────
+spring.mail.host=${SMTP_HOST:localhost}
+spring.mail.port=${SMTP_PORT:1025}
+spring.mail.username=${SMTP_USER:}
+spring.mail.password=${SMTP_PASS:}
+spring.mail.properties.mail.smtp.auth=${SMTP_AUTH:false}
+spring.mail.properties.mail.smtp.starttls.enable=${SMTP_STARTTLS:false}
+spring.mail.properties.mail.smtp.starttls.required=${SMTP_STARTTLS:false}
+versus.mail.from=${MAIL_FROM:noreply@versus-dev.local}
+versus.mail.from-name=${MAIL_FROM_NAME:Versus Dev}
+versus.frontend.base-url=${FRONTEND_BASE_URL:http://localhost:4200}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -33,3 +33,23 @@ versus.storage.r2.secret-access-key=${R2_SECRET_ACCESS_KEY:}
 versus.storage.max-file-size-bytes=${MEDIA_MAX_FILE_SIZE_BYTES:10485760}
 versus.storage.max-avatar-size-bytes=${MEDIA_MAX_AVATAR_SIZE_BYTES:2097152}
 versus.storage.allowed-content-types=image/jpeg,image/png,image/webp,image/gif,video/mp4,audio/mpeg,audio/ogg,application/pdf,text/plain
+
+# ─── Mail / SMTP ──────────────────────────────────────────────────────────────
+spring.mail.host=${SMTP_HOST:smtp.gmail.com}
+spring.mail.port=${SMTP_PORT:587}
+spring.mail.username=${SMTP_USER:}
+spring.mail.password=${SMTP_PASS:}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=5000
+
+versus.mail.from=${MAIL_FROM:noreply@versus-game.com}
+versus.mail.from-name=${MAIL_FROM_NAME:Versus Game}
+# URL base del frontend para construir los enlaces de los correos
+versus.frontend.base-url=${FRONTEND_BASE_URL:http://localhost:4200}
+# Duración del token de verificación de email (segundos, default 24h)
+versus.auth.verification-token-expiry=${VERIFICATION_TOKEN_EXPIRY:86400}
+# Duración del token de reset de contraseña (segundos, default 15min)
+versus.auth.reset-token-expiry=${RESET_TOKEN_EXPIRY:900}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -39,14 +39,17 @@ spring.mail.host=${SMTP_HOST:smtp.gmail.com}
 spring.mail.port=${SMTP_PORT:587}
 spring.mail.username=${SMTP_USER:}
 spring.mail.password=${SMTP_PASS:}
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.auth=${SMTP_AUTH:true}
+spring.mail.properties.mail.smtp.starttls.enable=${SMTP_STARTTLS:true}
+spring.mail.properties.mail.smtp.starttls.required=${SMTP_STARTTLS:true}
 spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=5000
 
 versus.mail.from=${MAIL_FROM:noreply@versus-game.com}
 versus.mail.from-name=${MAIL_FROM_NAME:Versus Game}
+versus.email.enabled=${VERSUS_EMAIL_ENABLED:false}
+versus.email.from=${MAIL_FROM:noreply@versus-game.com}
+versus.email.from-name=${MAIL_FROM_NAME:Versus Game}
 # URL base del frontend para construir los enlaces de los correos
 versus.frontend.base-url=${FRONTEND_BASE_URL:http://localhost:4200}
 # Duración del token de verificación de email (segundos, default 24h)

--- a/backend/src/main/resources/templates/email/password-reset.html
+++ b/backend/src/main/resources/templates/email/password-reset.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Recupera tu contraseña en Versus</title>
+  <style>
+    body { margin: 0; padding: 0; background: #0d0d0f; font-family: Inter, Arial, sans-serif; }
+    .wrapper { max-width: 560px; margin: 40px auto; background: #1a1a1f; border-radius: 12px; overflow: hidden; }
+    .header { background: #1a5276; padding: 32px; text-align: center; }
+    .header h1 { margin: 0; font-size: 48px; letter-spacing: 4px; color: #ffffff; font-family: 'Bebas Neue', Impact, sans-serif; }
+    .body { padding: 40px 48px; }
+    .body p { color: #b0b0c0; font-size: 15px; line-height: 1.7; margin: 0 0 20px; }
+    .body .name { color: #ffffff; font-weight: 600; }
+    .btn { display: inline-block; margin: 8px 0 24px; padding: 14px 32px; background: #4a90d9;
+           color: #ffffff; text-decoration: none; border-radius: 8px; font-size: 15px;
+           font-weight: 600; letter-spacing: 0.5px; }
+    .note { font-size: 13px; color: #606070; }
+    .note a { color: #4a90d9; word-break: break-all; }
+    .footer { border-top: 1px solid #2a2a3f; padding: 20px 48px; text-align: center; }
+    .footer p { margin: 0; font-size: 12px; color: #404050; }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="header"><h1>VERSUS</h1></div>
+    <div class="body">
+      <p>Hola, <span class="name" th:text="${username}">jugador</span>.</p>
+      <p>Recibimos una solicitud para restablecer la contraseña de tu cuenta. Haz clic en el botón de abajo para crear una nueva:</p>
+      <p style="text-align:center;">
+        <a class="btn" th:href="${resetUrl}">Restablecer contraseña</a>
+      </p>
+      <p class="note">
+        Si el botón no funciona, copia y pega este enlace en tu navegador:<br/>
+        <a th:href="${resetUrl}" th:text="${resetUrl}"></a>
+      </p>
+      <p class="note">
+        Este enlace expira en <strong>15 minutos</strong>.<br/>
+        Si no solicitaste el cambio de contraseña, ignora este correo y tu cuenta permanecerá segura.
+      </p>
+    </div>
+    <div class="footer">
+      <p>&copy; 2025 Versus Game. Todos los derechos reservados.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/email/shared/generic.html
+++ b/backend/src/main/resources/templates/email/shared/generic.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${title}">Versus</title>
+</head>
+<body style="margin:0;padding:24px;background:#0d0d0f;color:#f5f5f5;font-family:Arial,sans-serif;">
+<main style="max-width:560px;margin:0 auto;background:#18181b;border:1px solid #27272a;border-radius:8px;padding:28px;">
+    <h1 style="margin:0 0 16px;font-size:24px;" th:text="${title}">Versus</h1>
+    <div style="font-size:15px;line-height:1.6;color:#d4d4d8;" th:utext="${content}">
+        Contenido del correo
+    </div>
+</main>
+</body>
+</html>

--- a/backend/src/main/resources/templates/email/verification.html
+++ b/backend/src/main/resources/templates/email/verification.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Verifica tu cuenta en Versus</title>
+  <style>
+    body { margin: 0; padding: 0; background: #0d0d0f; font-family: Inter, Arial, sans-serif; }
+    .wrapper { max-width: 560px; margin: 40px auto; background: #1a1a1f; border-radius: 12px; overflow: hidden; }
+    .header { background: #c0392b; padding: 32px; text-align: center; }
+    .header h1 { margin: 0; font-size: 48px; letter-spacing: 4px; color: #ffffff; font-family: 'Bebas Neue', Impact, sans-serif; }
+    .body { padding: 40px 48px; }
+    .body p { color: #b0b0c0; font-size: 15px; line-height: 1.7; margin: 0 0 20px; }
+    .body .name { color: #ffffff; font-weight: 600; }
+    .btn { display: inline-block; margin: 8px 0 24px; padding: 14px 32px; background: #c0392b;
+           color: #ffffff; text-decoration: none; border-radius: 8px; font-size: 15px;
+           font-weight: 600; letter-spacing: 0.5px; }
+    .note { font-size: 13px; color: #606070; }
+    .note a { color: #4a90d9; word-break: break-all; }
+    .footer { border-top: 1px solid #2a2a3f; padding: 20px 48px; text-align: center; }
+    .footer p { margin: 0; font-size: 12px; color: #404050; }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="header"><h1>VERSUS</h1></div>
+    <div class="body">
+      <p>Hola, <span class="name" th:text="${username}">jugador</span>.</p>
+      <p>Gracias por registrarte. Haz clic en el botón de abajo para verificar tu correo y activar tu cuenta:</p>
+      <p style="text-align:center;">
+        <a class="btn" th:href="${verifyUrl}">Verificar mi cuenta</a>
+      </p>
+      <p class="note">
+        Si el botón no funciona, copia y pega este enlace en tu navegador:<br/>
+        <a th:href="${verifyUrl}" th:text="${verifyUrl}"></a>
+      </p>
+      <p class="note">Este enlace expira en <strong>24 horas</strong>. Si no creaste esta cuenta, puedes ignorar este correo.</p>
+    </div>
+    <div class="footer">
+      <p>&copy; 2025 Versus Game. Todos los derechos reservados.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/backend/src/test/java/com/versus/api/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/versus/api/auth/AuthServiceTest.java
@@ -3,6 +3,9 @@ package com.versus.api.auth;
 import com.versus.api.auth.domain.RefreshToken;
 import com.versus.api.auth.dto.AuthResponse;
 import com.versus.api.auth.dto.LoginRequest;
+import com.versus.api.auth.dto.MessageResponse;
+import com.versus.api.auth.dto.PasswordResetConfirmRequest;
+import com.versus.api.auth.dto.PasswordResetRequest;
 import com.versus.api.auth.dto.RegisterRequest;
 import com.versus.api.auth.repo.RefreshTokenRepository;
 import com.versus.api.common.exception.ApiException;
@@ -29,6 +32,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @DisplayName("AuthService")
@@ -39,6 +43,7 @@ class AuthServiceTest {
     @Mock RefreshTokenRepository refreshTokens;
     @Mock PasswordEncoder passwordEncoder;
     @Mock JwtService jwt;
+    @Mock EmailService emailService;
 
     @InjectMocks AuthService authService;
 
@@ -50,13 +55,10 @@ class AuthServiceTest {
     @Nested
     class Register {
 
-        private static final String USERNAME      = "player1";
-        private static final String EMAIL         = "player1@versus.com";
-        private static final String PASSWORD      = "Segura123!";
-        private static final String HASHED_PW    = "$2a$10$mockedhash";
-        private static final String ACCESS_TOKEN  = "mocked.access.token";
-        private static final String REFRESH_TOKEN = "mocked.refresh.token";
-        private static final String REFRESH_HASH  = "mockedrefreshhash";
+        private static final String USERNAME = "player1";
+        private static final String EMAIL    = "player1@versus.com";
+        private static final String PASSWORD = "Segura123!";
+        private static final String HASHED_PW = "$2a$10$mockedhash";
 
         private RegisterRequest validRequest() {
             return new RegisterRequest(USERNAME, EMAIL, PASSWORD);
@@ -71,67 +73,58 @@ class AuthServiceTest {
                 u.setId(UUID.randomUUID());
                 return u;
             });
-            when(jwt.generateAccessToken(any())).thenReturn(ACCESS_TOKEN);
-            when(jwt.generateRefreshToken(any())).thenReturn(REFRESH_TOKEN);
-            when(jwt.hash(REFRESH_TOKEN)).thenReturn(REFRESH_HASH);
-            when(jwt.getRefreshExpiry()).thenReturn(604800L);
+            // EmailService.sendVerificationEmail es void; Mockito lo deja como no-op por defecto
         }
 
-        @DisplayName("Camino feliz: registro exitoso con datos válidos")
+        @DisplayName("Camino feliz: devuelve mensaje de confirmación no vacío")
         @Test
-        void caminoFeliz_devuelveAuthResponseCompleta() {
+        void caminoFeliz_devuelveMensajeConfirmacion() {
             stubHappyPath();
 
-            AuthResponse res = authService.register(validRequest());
+            MessageResponse res = authService.register(validRequest());
 
-            assertThat(res.accessToken()).isEqualTo(ACCESS_TOKEN);
-            assertThat(res.refreshToken()).isEqualTo(REFRESH_TOKEN);
-            assertThat(res.user().username()).isEqualTo(USERNAME);
-            assertThat(res.user().role()).isEqualTo("PLAYER");
-            assertThat(res.user().id()).isNotNull();
+            assertThat(res.message()).isNotBlank();
         }
 
-        @DisplayName("Registro con email duplicado lanza conflicto")
+        @DisplayName("Camino feliz: el usuario se guarda con enabled=false (pendiente de verificar)")
         @Test
-        void emailDuplicado_lanzaConflict() {
-            when(users.existsByEmail(EMAIL)).thenReturn(true);
-
-            assertThatThrownBy(() -> authService.register(validRequest()))
-                    .isInstanceOf(ApiException.class)
-                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
-                            .isEqualTo(ErrorCode.CONFLICT));
-        }
-
-        @DisplayName("Registro con username duplicado lanza conflicto")
-        @Test
-        void usernameDuplicado_lanzaConflict() {
-            when(users.existsByEmail(EMAIL)).thenReturn(false);
-            when(users.existsByUsername(USERNAME)).thenReturn(true);
-
-            assertThatThrownBy(() -> authService.register(validRequest()))
-                    .isInstanceOf(ApiException.class)
-                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
-                            .isEqualTo(ErrorCode.CONFLICT));
-        }
-
-        @DisplayName("El refresh token se persiste con los campos correctos")
-        @Test
-        void caminoFeliz_persisteRefreshTokenConCamposCorrectos() {
+        void caminoFeliz_usuarioGuardadoConEnabledFalse() {
             stubHappyPath();
 
             authService.register(validRequest());
 
-            ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
-            verify(refreshTokens).save(captor.capture());
-
-            RefreshToken saved = captor.getValue();
-            assertThat(saved.getRevoked()).isFalse();
-            assertThat(saved.getTokenHash()).isEqualTo(REFRESH_HASH);
-            assertThat(saved.getUserId()).isNotNull();
-            assertThat(saved.getExpiresAt()).isAfter(Instant.now());
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(captor.capture());
+            assertThat(captor.getValue().getEnabled()).isFalse();
         }
 
-        @DisplayName("El usuario guardado tiene role PLAYER")
+        @DisplayName("Camino feliz: el usuario se guarda con un token de verificación no nulo")
+        @Test
+        void caminoFeliz_tokenDeVerificacionNoNulo() {
+            stubHappyPath();
+
+            authService.register(validRequest());
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(captor.capture());
+            assertThat(captor.getValue().getVerificationToken()).isNotBlank();
+        }
+
+        @DisplayName("Camino feliz: se envía email de verificación con el correo y token del usuario")
+        @Test
+        void caminoFeliz_emailDeVerificacionEnviado() {
+            stubHappyPath();
+
+            authService.register(validRequest());
+
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(userCaptor.capture());
+            String savedToken = userCaptor.getValue().getVerificationToken();
+
+            verify(emailService).sendVerificationEmail(EMAIL, USERNAME, savedToken);
+        }
+
+        @DisplayName("Camino feliz: el usuario se guarda con role PLAYER")
         @Test
         void usuarioGuardado_tieneRolePlayer() {
             stubHappyPath();
@@ -143,7 +136,7 @@ class AuthServiceTest {
             assertThat(captor.getValue().getRole()).isEqualTo(Role.PLAYER);
         }
 
-        @DisplayName("El usuario guardado tiene isActive true")
+        @DisplayName("Camino feliz: el usuario se guarda con isActive=true")
         @Test
         void usuarioGuardado_tieneIsActiveTrue() {
             stubHappyPath();
@@ -155,7 +148,7 @@ class AuthServiceTest {
             assertThat(captor.getValue().getIsActive()).isTrue();
         }
 
-        @DisplayName("La contraseña se guarda hasheada, no en plano")
+        @DisplayName("Camino feliz: la contraseña se guarda hasheada, no en plano")
         @Test
         void contrasena_seGuardaHasheadaNoEnPlano() {
             stubHappyPath();
@@ -169,17 +162,30 @@ class AuthServiceTest {
                     .isNotEqualTo(PASSWORD);
         }
 
-        @DisplayName("Usuario sin avatar tiene avatarUrl null sin lanzar excepción")
+        @DisplayName("Registro con email duplicado lanza CONFLICT")
         @Test
-        void usuarioSinAvatar_avatarUrlEsNullSinExcepcion() {
-            stubHappyPath();
+        void emailDuplicado_lanzaConflict() {
+            when(users.existsByEmail(EMAIL)).thenReturn(true);
 
-            AuthResponse res = authService.register(validRequest());
-
-            assertThat(res.user().avatarUrl()).isNull();
+            assertThatThrownBy(() -> authService.register(validRequest()))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
+                            .isEqualTo(ErrorCode.CONFLICT));
         }
 
-        @DisplayName("Si email y username ambos están duplicados, se lanza conflicto por email primero")
+        @DisplayName("Registro con username duplicado lanza CONFLICT")
+        @Test
+        void usernameDuplicado_lanzaConflict() {
+            when(users.existsByEmail(EMAIL)).thenReturn(false);
+            when(users.existsByUsername(USERNAME)).thenReturn(true);
+
+            assertThatThrownBy(() -> authService.register(validRequest()))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
+                            .isEqualTo(ErrorCode.CONFLICT));
+        }
+
+        @DisplayName("Email y username ambos duplicados: se lanza conflicto por email primero")
         @Test
         void emailYUsernameAmbosDuplicados_lanzaConflictPorEmailPrimero() {
             when(users.existsByEmail(EMAIL)).thenReturn(true);
@@ -192,14 +198,16 @@ class AuthServiceTest {
             verify(users, never()).existsByUsername(any());
         }
 
-        @DisplayName("Los tokens de acceso y refresh son distintos")
+        @DisplayName("Email duplicado: no se envía correo ni se guarda usuario")
         @Test
-        void tokens_accessYRefreshSonDistintos() {
-            stubHappyPath();
+        void emailDuplicado_noEnviaEmailNiGuardaUsuario() {
+            when(users.existsByEmail(EMAIL)).thenReturn(true);
 
-            AuthResponse res = authService.register(validRequest());
+            assertThatThrownBy(() -> authService.register(validRequest()))
+                    .isInstanceOf(ApiException.class);
 
-            assertThat(res.accessToken()).isNotEqualTo(res.refreshToken());
+            verify(users, never()).save(any());
+            verifyNoInteractions(emailService);
         }
     }
 
@@ -222,6 +230,7 @@ class AuthServiceTest {
             return new LoginRequest(EMAIL, PASSWORD);
         }
 
+        /** Usuario con enabled=null (Boolean.FALSE.equals(null)==false → login pasa). */
         private User activeUser() {
             return User.builder()
                     .id(UUID.randomUUID())
@@ -279,7 +288,7 @@ class AuthServiceTest {
                             .isEqualTo(ErrorCode.UNAUTHORIZED));
         }
 
-        @DisplayName("Usuario inactivo lanza UNAUTHORIZED")
+        @DisplayName("Usuario con isActive=false lanza UNAUTHORIZED")
         @Test
         void usuarioInactivo_lanzaUnauthorized() {
             User inactive = User.builder()
@@ -322,6 +331,31 @@ class AuthServiceTest {
             verify(passwordEncoder, never()).matches(any(), any());
         }
 
+        @DisplayName("Usuario con email no verificado (enabled=false) lanza EMAIL_NOT_VERIFIED")
+        @Test
+        void usuarioNoVerificado_lanzaEmailNotVerified() {
+            User unverified = User.builder()
+                    .id(UUID.randomUUID()).email(EMAIL).passwordHash(HASHED_PW)
+                    .role(Role.PLAYER).isActive(true).enabled(false).build();
+            when(users.findByEmail(EMAIL)).thenReturn(Optional.of(unverified));
+
+            assertThatThrownBy(() -> authService.login(validRequest()))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
+                            .isEqualTo(ErrorCode.EMAIL_NOT_VERIFIED));
+
+            verify(passwordEncoder, never()).matches(any(), any());
+        }
+
+        @DisplayName("enabled=null no bloquea el login (Boolean.FALSE.equals(null) es false)")
+        @Test
+        void enabledNull_noBloqueoLogin() {
+            User nullEnabled = activeUser(); // builder no setea enabled → null
+            stubHappyPath(nullEnabled);
+
+            assertThatCode(() -> authService.login(validRequest())).doesNotThrowAnyException();
+        }
+
         @DisplayName("Camino feliz: el refresh token se persiste con userId correcto")
         @Test
         void caminoFeliz_persisteRefreshTokenConUserId() {
@@ -352,27 +386,6 @@ class AuthServiceTest {
             assertThat(noEmail.getMessage()).isEqualTo(wrongPw.getMessage());
         }
 
-        @DisplayName("isActive=null no bloquea el login (Boolean.FALSE.equals(null) es false)")
-        @Test
-        void isActiveNull_noBloqueoLogin() {
-            User nullActive = User.builder()
-                    .id(UUID.randomUUID()).email(EMAIL).passwordHash(HASHED_PW)
-                    .role(Role.PLAYER).isActive(null).build();
-            stubHappyPath(nullActive);
-
-            assertThatCode(() -> authService.login(validRequest())).doesNotThrowAnyException();
-        }
-
-        @DisplayName("Camino feliz: accessToken y refreshToken son distintos")
-        @Test
-        void caminoFeliz_accessYRefreshSonDistintos() {
-            stubHappyPath(activeUser());
-
-            AuthResponse res = authService.login(validRequest());
-
-            assertThat(res.accessToken()).isNotEqualTo(res.refreshToken());
-        }
-
         @DisplayName("Camino feliz: la respuesta contiene el id del usuario")
         @Test
         void caminoFeliz_respuestaContieneIdDeUsuario() {
@@ -386,6 +399,275 @@ class AuthServiceTest {
     }
 
     // ═══════════════════════════════════════════════════════════════════════
+    // VERIFY EMAIL
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @DisplayName("Verificación de email")
+    @Nested
+    class VerifyEmail {
+
+        private static final String TOKEN = "valid-verification-token-abc123";
+
+        private User unverifiedUser() {
+            return User.builder()
+                    .id(UUID.randomUUID())
+                    .email("player@versus.com")
+                    .username("player1")
+                    .passwordHash("hash")
+                    .role(Role.PLAYER)
+                    .isActive(true)
+                    .enabled(false)
+                    .verificationToken(TOKEN)
+                    .verificationTokenExpiry(Instant.now().plusSeconds(3600))
+                    .build();
+        }
+
+        @DisplayName("Token válido: habilita la cuenta y devuelve mensaje")
+        @Test
+        void tokenValido_habilitaCuenta() {
+            User user = unverifiedUser();
+            when(users.findByVerificationToken(TOKEN)).thenReturn(Optional.of(user));
+
+            MessageResponse res = authService.verifyEmail(TOKEN);
+
+            assertThat(res.message()).isNotBlank();
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(captor.capture());
+            assertThat(captor.getValue().getEnabled()).isTrue();
+        }
+
+        @DisplayName("Token válido: limpia el token y su expiración tras activar")
+        @Test
+        void tokenValido_limpiaCamposToken() {
+            User user = unverifiedUser();
+            when(users.findByVerificationToken(TOKEN)).thenReturn(Optional.of(user));
+
+            authService.verifyEmail(TOKEN);
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(captor.capture());
+            assertThat(captor.getValue().getVerificationToken()).isNull();
+            assertThat(captor.getValue().getVerificationTokenExpiry()).isNull();
+        }
+
+        @DisplayName("Token no encontrado lanza TOKEN_INVALID")
+        @Test
+        void tokenNoEncontrado_lanzaTokenInvalid() {
+            when(users.findByVerificationToken(TOKEN)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.verifyEmail(TOKEN))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
+                            .isEqualTo(ErrorCode.TOKEN_INVALID));
+        }
+
+        @DisplayName("Token expirado lanza TOKEN_EXPIRED")
+        @Test
+        void tokenExpirado_lanzaTokenExpired() {
+            User user = unverifiedUser();
+            user.setVerificationTokenExpiry(Instant.now().minusSeconds(1));
+            when(users.findByVerificationToken(TOKEN)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> authService.verifyEmail(TOKEN))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
+                            .isEqualTo(ErrorCode.TOKEN_EXPIRED));
+
+            verify(users, never()).save(any());
+        }
+
+        @DisplayName("Cuenta ya habilitada: devuelve mensaje sin modificar usuario")
+        @Test
+        void cuentaYaHabilitada_devuelveMensajeSinGuardar() {
+            User already = unverifiedUser();
+            already.setEnabled(true);
+            when(users.findByVerificationToken(TOKEN)).thenReturn(Optional.of(already));
+
+            MessageResponse res = authService.verifyEmail(TOKEN);
+
+            assertThat(res.message()).isNotBlank();
+            verify(users, never()).save(any());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // PASSWORD RESET — REQUEST
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @DisplayName("Solicitud de reset de contraseña")
+    @Nested
+    class PasswordResetRequest {
+
+        private static final String EMAIL = "player@versus.com";
+
+        private User existingUser() {
+            return User.builder()
+                    .id(UUID.randomUUID()).email(EMAIL).username("player1")
+                    .passwordHash("hash").role(Role.PLAYER).isActive(true).enabled(true)
+                    .build();
+        }
+
+        @DisplayName("Email registrado: genera token y envía correo")
+        @Test
+        void emailExistente_generaTokenYEnviaCorreo() {
+            User user = existingUser();
+            when(users.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+            when(users.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            authService.requestPasswordReset(new com.versus.api.auth.dto.PasswordResetRequest(EMAIL));
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(captor.capture());
+            assertThat(captor.getValue().getPasswordResetToken()).isNotBlank();
+            assertThat(captor.getValue().getPasswordResetTokenExpiry()).isAfter(Instant.now());
+            verify(emailService).sendPasswordResetEmail(eq(EMAIL), anyString(), anyString());
+        }
+
+        @DisplayName("Email no registrado: no lanza excepción (respuesta genérica por seguridad)")
+        @Test
+        void emailNoExistente_noLanzaExcepcion() {
+            when(users.findByEmail(EMAIL)).thenReturn(Optional.empty());
+
+            assertThatCode(() -> authService.requestPasswordReset(
+                    new com.versus.api.auth.dto.PasswordResetRequest(EMAIL)))
+                    .doesNotThrowAnyException();
+        }
+
+        @DisplayName("Email no registrado: no envía correo ni guarda usuario")
+        @Test
+        void emailNoExistente_noEnviaCorreoNiGuardaUsuario() {
+            when(users.findByEmail(EMAIL)).thenReturn(Optional.empty());
+
+            authService.requestPasswordReset(new com.versus.api.auth.dto.PasswordResetRequest(EMAIL));
+
+            verifyNoInteractions(emailService);
+            verify(users, never()).save(any());
+        }
+
+        @DisplayName("Siempre devuelve el mismo mensaje independientemente del email")
+        @Test
+        void siempreDevuelveMismoMensaje() {
+            when(users.findByEmail(EMAIL)).thenReturn(Optional.empty());
+            MessageResponse res = authService.requestPasswordReset(
+                    new com.versus.api.auth.dto.PasswordResetRequest(EMAIL));
+
+            assertThat(res.message()).isNotBlank();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // PASSWORD RESET — CONFIRM
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @DisplayName("Confirmación de reset de contraseña")
+    @Nested
+    class PasswordResetConfirm {
+
+        private static final String TOKEN       = "valid-reset-token-xyz789";
+        private static final String NEW_PASSWORD = "NuevaSegura456!";
+        private static final String NEW_HASH    = "$2a$10$newhash";
+
+        private User userWithResetToken() {
+            return User.builder()
+                    .id(UUID.randomUUID()).email("player@versus.com").username("player1")
+                    .passwordHash("oldhash").role(Role.PLAYER).isActive(true).enabled(true)
+                    .passwordResetToken(TOKEN)
+                    .passwordResetTokenExpiry(Instant.now().plusSeconds(900))
+                    .build();
+        }
+
+        @DisplayName("Token válido: actualiza la contraseña hasheada")
+        @Test
+        void tokenValido_actualizaPasswordHasheada() {
+            User user = userWithResetToken();
+            when(users.findByPasswordResetToken(TOKEN)).thenReturn(Optional.of(user));
+            when(passwordEncoder.encode(NEW_PASSWORD)).thenReturn(NEW_HASH);
+            when(users.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            authService.confirmPasswordReset(new PasswordResetConfirmRequest(TOKEN, NEW_PASSWORD));
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(captor.capture());
+            assertThat(captor.getValue().getPasswordHash()).isEqualTo(NEW_HASH);
+        }
+
+        @DisplayName("Token válido: limpia el token y su expiración tras el cambio")
+        @Test
+        void tokenValido_limpiaCamposToken() {
+            User user = userWithResetToken();
+            when(users.findByPasswordResetToken(TOKEN)).thenReturn(Optional.of(user));
+            when(passwordEncoder.encode(NEW_PASSWORD)).thenReturn(NEW_HASH);
+            when(users.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            authService.confirmPasswordReset(new PasswordResetConfirmRequest(TOKEN, NEW_PASSWORD));
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(users).save(captor.capture());
+            assertThat(captor.getValue().getPasswordResetToken()).isNull();
+            assertThat(captor.getValue().getPasswordResetTokenExpiry()).isNull();
+        }
+
+        @DisplayName("Token válido: la nueva contraseña es cifrada con PasswordEncoder")
+        @Test
+        void tokenValido_contrasenaCifradaConEncoder() {
+            User user = userWithResetToken();
+            when(users.findByPasswordResetToken(TOKEN)).thenReturn(Optional.of(user));
+            when(passwordEncoder.encode(NEW_PASSWORD)).thenReturn(NEW_HASH);
+            when(users.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            authService.confirmPasswordReset(new PasswordResetConfirmRequest(TOKEN, NEW_PASSWORD));
+
+            verify(passwordEncoder).encode(NEW_PASSWORD);
+        }
+
+        @DisplayName("Token no encontrado lanza TOKEN_INVALID")
+        @Test
+        void tokenNoExistente_lanzaTokenInvalid() {
+            when(users.findByPasswordResetToken(TOKEN)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.confirmPasswordReset(
+                    new PasswordResetConfirmRequest(TOKEN, NEW_PASSWORD)))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
+                            .isEqualTo(ErrorCode.TOKEN_INVALID));
+
+            verify(passwordEncoder, never()).encode(any());
+            verify(users, never()).save(any());
+        }
+
+        @DisplayName("Token expirado lanza TOKEN_EXPIRED")
+        @Test
+        void tokenExpirado_lanzaTokenExpired() {
+            User user = userWithResetToken();
+            user.setPasswordResetTokenExpiry(Instant.now().minusSeconds(1));
+            when(users.findByPasswordResetToken(TOKEN)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> authService.confirmPasswordReset(
+                    new PasswordResetConfirmRequest(TOKEN, NEW_PASSWORD)))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(ex -> assertThat(((ApiException) ex).getCode())
+                            .isEqualTo(ErrorCode.TOKEN_EXPIRED));
+
+            verify(passwordEncoder, never()).encode(any());
+            verify(users, never()).save(any());
+        }
+
+        @DisplayName("Token válido: devuelve mensaje de confirmación")
+        @Test
+        void tokenValido_devuelveMensaje() {
+            User user = userWithResetToken();
+            when(users.findByPasswordResetToken(TOKEN)).thenReturn(Optional.of(user));
+            when(passwordEncoder.encode(NEW_PASSWORD)).thenReturn(NEW_HASH);
+            when(users.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            MessageResponse res = authService.confirmPasswordReset(
+                    new PasswordResetConfirmRequest(TOKEN, NEW_PASSWORD));
+
+            assertThat(res.message()).isNotBlank();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
     // REFRESH
     // ═══════════════════════════════════════════════════════════════════════
 
@@ -393,12 +675,12 @@ class AuthServiceTest {
     @Nested
     class Refresh {
 
-        private static final String RAW_TOKEN       = "raw.refresh.token";
-        private static final String TOKEN_HASH      = "hashedtoken123";
-        private static final String NEW_ACCESS      = "new.access.token";
-        private static final String NEW_REFRESH     = "new.refresh.token";
+        private static final String RAW_TOKEN        = "raw.refresh.token";
+        private static final String TOKEN_HASH       = "hashedtoken123";
+        private static final String NEW_ACCESS       = "new.access.token";
+        private static final String NEW_REFRESH      = "new.refresh.token";
         private static final String NEW_REFRESH_HASH = "newhashedrefresh";
-        private static final UUID   USER_ID         = UUID.randomUUID();
+        private static final UUID   USER_ID          = UUID.randomUUID();
 
         private RefreshToken validStoredToken() {
             return RefreshToken.builder()
@@ -547,17 +829,6 @@ class AuthServiceTest {
                     .isInstanceOf(ApiException.class)
                     .satisfies(ex -> assertThat(((ApiException) ex).getCode())
                             .isEqualTo(ErrorCode.UNAUTHORIZED));
-        }
-
-        @DisplayName("Camino feliz: el nuevo refreshToken es distinto al original")
-        @Test
-        void caminoFeliz_nuevoRefreshTokenDistintoAlOriginal() {
-            stubHappyPath(validStoredToken(), storedUser());
-
-            AuthResponse res = authService.refresh(RAW_TOKEN);
-
-            assertThat(res.refreshToken()).isNotEqualTo(RAW_TOKEN);
-            assertThat(res.accessToken()).isNotEqualTo(RAW_TOKEN);
         }
 
         @DisplayName("Camino feliz: se persiste el nuevo refresh token con revoked=false")

--- a/backend/src/test/java/com/versus/api/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/versus/api/auth/AuthServiceTest.java
@@ -16,6 +16,7 @@ import com.versus.api.users.domain.User;
 import com.versus.api.users.repo.UserRepository;
 import io.jsonwebtoken.Claims;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -46,6 +48,12 @@ class AuthServiceTest {
     @Mock EmailService emailService;
 
     @InjectMocks AuthService authService;
+
+    @BeforeEach
+    void injectConfigValues() {
+        ReflectionTestUtils.setField(authService, "verificationTokenExpiry", 86400L);
+        ReflectionTestUtils.setField(authService, "resetTokenExpiry", 900L);
+    }
 
     // ═══════════════════════════════════════════════════════════════════════
     // REGISTER

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -13,3 +13,13 @@ versus.jwt.secret=test-secret-test-secret-test-secret-test-secret-test-secret-te
 versus.jwt.access-expiry=900
 versus.jwt.refresh-expiry=604800
 versus.seed.enabled=false
+
+# Mail (valores seguros para tests — no se conecta a ningún servidor real)
+spring.mail.host=localhost
+spring.mail.port=3025
+spring.mail.test-connection=false
+versus.mail.from=noreply@versus-test.com
+versus.mail.from-name=Versus Test
+versus.frontend.base-url=http://localhost:4200
+versus.auth.verification-token-expiry=86400
+versus.auth.reset-token-expiry=900

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,21 +13,42 @@ services:
     ports:
       - "5432:5432"
 
+  mailhog:
+    image: mailhog/mailhog:latest
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP (recibe todos los correos del backend)
+      - "8025:8025"   # Web UI — abre http://localhost:8025 para ver los emails
+    networks:
+      - app-network
+
   backend:
     build:
       context: ./backend
       dockerfile: Dockerfile
       target: development      # stage development
     ports:
-      - "8080:8080"           
-      - "5005:5005"            
+      - "8080:8080"
+      - "5005:5005"
     volumes:
       - ./backend:/app         # Monta el código fuente del host
       - maven_cache:/root/.m2  # Caché de Maven entre reinicios
+    depends_on:
+      - mailhog
     environment:
       SPRING_PROFILES_ACTIVE: dev
       SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
       DDL_AUTO: create-drop    # Recrea la BD en cada arranque (dev)
+      # ── Mail (leído del .env — MailHog por defecto, Gmail si se configura) ──
+      SMTP_HOST: ${SMTP_HOST:-mailhog}
+      SMTP_PORT: ${SMTP_PORT:-1025}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SMTP_AUTH: ${SMTP_AUTH:-false}
+      SMTP_STARTTLS: ${SMTP_STARTTLS:-false}
+      MAIL_FROM: ${MAIL_FROM:-noreply@versus-dev.local}
+      MAIL_FROM_NAME: ${MAIL_FROM_NAME:-Versus Dev}
+      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:4200}
 
   frontend:
     build:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,6 +48,7 @@ services:
       SMTP_STARTTLS: ${SMTP_STARTTLS:-false}
       MAIL_FROM: ${MAIL_FROM:-noreply@versus-dev.local}
       MAIL_FROM_NAME: ${MAIL_FROM_NAME:-Versus Dev}
+      VERSUS_EMAIL_ENABLED: ${VERSUS_EMAIL_ENABLED:-false}
       FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:4200}
 
   frontend:

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -17,6 +17,22 @@ export const routes: Routes = [
     path: 'register',
     loadComponent: () => import('./features/auth/pages/register/register').then(m => m.Register),
   },
+  {
+    path: 'check-email',
+    loadComponent: () => import('./features/auth/pages/check-email/check-email').then(m => m.CheckEmail),
+  },
+  {
+    path: 'verify-email',
+    loadComponent: () => import('./features/auth/pages/verify-email/verify-email').then(m => m.VerifyEmail),
+  },
+  {
+    path: 'forgot-password',
+    loadComponent: () => import('./features/auth/pages/forgot-password/forgot-password').then(m => m.ForgotPassword),
+  },
+  {
+    path: 'reset-password',
+    loadComponent: () => import('./features/auth/pages/reset-password/reset-password').then(m => m.ResetPassword),
+  },
 
   // ─── Jugador ──────────────────────────────────────────────────────────────
   {

--- a/frontend/src/app/core/models/auth.models.ts
+++ b/frontend/src/app/core/models/auth.models.ts
@@ -38,3 +38,16 @@ export interface ApiError {
   message: string;
   status: number;
 }
+
+export interface MessageResponse {
+  message: string;
+}
+
+export interface PasswordResetRequest {
+  email: string;
+}
+
+export interface PasswordResetConfirmRequest {
+  token: string;
+  newPassword: string;
+}

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -6,6 +6,9 @@ import {
   AuthResponse,
   AuthUser,
   LoginRequest,
+  MessageResponse,
+  PasswordResetConfirmRequest,
+  PasswordResetRequest,
   RegisterRequest,
 } from '../models/auth.models';
 
@@ -28,10 +31,22 @@ export class AuthService {
       .pipe(tap((res) => this.persist(res)));
   }
 
-  register(req: RegisterRequest): Observable<AuthResponse> {
-    return this.http
-      .post<AuthResponse>(`${this.base}/auth/register`, req)
-      .pipe(tap((res) => this.persist(res)));
+  register(req: RegisterRequest): Observable<MessageResponse> {
+    return this.http.post<MessageResponse>(`${this.base}/auth/register`, req);
+  }
+
+  verifyEmail(token: string): Observable<MessageResponse> {
+    return this.http.get<MessageResponse>(`${this.base}/auth/verify`, {
+      params: { token },
+    });
+  }
+
+  requestPasswordReset(req: PasswordResetRequest): Observable<MessageResponse> {
+    return this.http.post<MessageResponse>(`${this.base}/auth/password-reset/request`, req);
+  }
+
+  confirmPasswordReset(req: PasswordResetConfirmRequest): Observable<MessageResponse> {
+    return this.http.post<MessageResponse>(`${this.base}/auth/password-reset/confirm`, req);
   }
 
   refresh(): Observable<AuthResponse> {

--- a/frontend/src/app/features/auth/components/forgot-password-form/forgot-password-form.html
+++ b/frontend/src/app/features/auth/components/forgot-password-form/forgot-password-form.html
@@ -1,0 +1,34 @@
+@if (!sent()) {
+  <form class="forgot-form" [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+
+    <div class="field">
+      <label class="field-label" for="fp-email">Correo electrónico</label>
+      <input
+        id="fp-email"
+        type="email"
+        class="vs-input"
+        [class.vs-input--error]="isInvalid('email')"
+        formControlName="email"
+        placeholder="tu@correo.com"
+        autocomplete="email"
+      />
+      @if (isInvalid('email')) {
+        <span class="field-error">{{ getError('email') }}</span>
+      }
+    </div>
+
+    @if (errorMessage()) {
+      <p class="form-error">{{ errorMessage() }}</p>
+    }
+
+    <app-vs-button type="submit" variant="primary" [loading]="loading()" [block]="true">
+      Enviar enlace de recuperación
+    </app-vs-button>
+  </form>
+} @else {
+  <div class="sent-msg">
+    <span class="sent-icon">✉</span>
+    <p>Si el correo está registrado, recibirás un enlace en tu bandeja de entrada.</p>
+    <p class="sent-note">Revisa también la carpeta de spam.</p>
+  </div>
+}

--- a/frontend/src/app/features/auth/components/forgot-password-form/forgot-password-form.scss
+++ b/frontend/src/app/features/auth/components/forgot-password-form/forgot-password-form.scss
@@ -1,0 +1,52 @@
+.forgot-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--vs-text-secondary);
+}
+
+.field-error {
+  font-size: 12px;
+  color: var(--vs-accent-red);
+}
+
+.form-error {
+  font-size: 13px;
+  color: var(--vs-accent-red);
+  text-align: center;
+  margin: 0;
+}
+
+.sent-msg {
+  text-align: center;
+  padding: 16px 0;
+
+  .sent-icon {
+    font-size: 48px;
+    display: block;
+    margin-bottom: 16px;
+  }
+
+  p {
+    font-size: 15px;
+    color: var(--vs-text-secondary);
+    line-height: 1.7;
+    margin: 0 0 8px;
+  }
+
+  .sent-note {
+    font-size: 13px;
+    color: var(--vs-text-muted);
+  }
+}

--- a/frontend/src/app/features/auth/components/forgot-password-form/forgot-password-form.ts
+++ b/frontend/src/app/features/auth/components/forgot-password-form/forgot-password-form.ts
@@ -1,0 +1,60 @@
+import { Component, inject, signal } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AuthService } from '../../../../core/services/auth.service';
+import { VsButtonComponent } from '../../../../shared/components/vs-button/vs-button.component';
+
+@Component({
+  selector: 'app-forgot-password-form',
+  imports: [ReactiveFormsModule, VsButtonComponent],
+  templateUrl: './forgot-password-form.html',
+  styleUrl: './forgot-password-form.scss',
+})
+export class ForgotPasswordForm {
+  readonly loading = signal(false);
+  readonly sent = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly form = inject(FormBuilder).group({
+    email: ['', [Validators.required, Validators.email]],
+  });
+
+  private readonly auth = inject(AuthService);
+
+  isInvalid(field: string): boolean {
+    const ctrl = this.form.get(field);
+    return !!(ctrl?.invalid && ctrl.touched);
+  }
+
+  getError(field: string): string | null {
+    const ctrl = this.form.get(field);
+    if (!ctrl?.errors || !ctrl.touched) return null;
+    const { required, email } = ctrl.errors;
+    if (required) return 'Este campo es obligatorio';
+    if (email)    return 'Introduce un correo válido';
+    return null;
+  }
+
+  onSubmit(): void {
+    this.form.markAllAsTouched();
+    if (this.form.invalid || this.loading()) return;
+
+    this.errorMessage.set(null);
+    this.loading.set(true);
+
+    this.auth.requestPasswordReset({ email: this.form.value.email! }).subscribe({
+      next: () => {
+        this.loading.set(false);
+        this.sent.set(true);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.loading.set(false);
+        if (err.status === 0) {
+          this.errorMessage.set('No se puede conectar con el servidor');
+        } else {
+          this.errorMessage.set(err?.error?.message ?? 'Error inesperado');
+        }
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/auth/components/login-form/login-form.html
+++ b/frontend/src/app/features/auth/components/login-form/login-form.html
@@ -42,6 +42,10 @@
     }
   </div>
 
+  <div class="forgot-link-wrap">
+    <a routerLink="/forgot-password" class="forgot-link">¿Olvidaste tu contraseña?</a>
+  </div>
+
   <!-- Error global -->
   @if (errorMessage()) {
     <div class="form-alert" role="alert">{{ errorMessage() }}</div>

--- a/frontend/src/app/features/auth/components/login-form/login-form.scss
+++ b/frontend/src/app/features/auth/components/login-form/login-form.scss
@@ -45,6 +45,22 @@
   color: var(--vs-accent-red);
 }
 
+.forgot-link-wrap {
+  text-align: right;
+  margin-bottom: 16px;
+}
+
+.forgot-link {
+  font-size: 13px;
+  color: var(--vs-text-muted);
+  text-decoration: none;
+  transition: color var(--vs-transition);
+
+  &:hover {
+    color: var(--vs-accent-blue);
+  }
+}
+
 .form-alert {
   background: rgba(230, 57, 70, 0.08);
   border: 1px solid var(--vs-accent-red);

--- a/frontend/src/app/features/auth/components/login-form/login-form.ts
+++ b/frontend/src/app/features/auth/components/login-form/login-form.ts
@@ -5,14 +5,14 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AuthService } from '../../../../core/services/auth.service';
 
 @Component({
   selector: 'app-login-form',
   standalone: true,
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, RouterLink],
   templateUrl: './login-form.html',
   styleUrl: './login-form.scss',
 })
@@ -26,7 +26,7 @@ export class LoginForm {
   private readonly auth = inject(AuthService);
   private readonly router = inject(Router);
 
-  constructor(private fb: FormBuilder) {
+  constructor(private readonly fb: FormBuilder) {
     this.form = this.fb.group({
       identifier: ['', [Validators.required, Validators.email]],
       password: ['', [Validators.required, Validators.minLength(6)]],

--- a/frontend/src/app/features/auth/components/register-form/register-form.ts
+++ b/frontend/src/app/features/auth/components/register-form/register-form.ts
@@ -28,7 +28,7 @@ export class RegisterForm {
   private readonly auth = inject(AuthService);
   private readonly router = inject(Router);
 
-  constructor(private fb: FormBuilder) {
+  constructor(private readonly fb: FormBuilder) {
     this.form = this.fb.group(
       {
         username: [
@@ -37,7 +37,7 @@ export class RegisterForm {
             Validators.required,
             Validators.minLength(3),
             Validators.maxLength(20),
-            Validators.pattern(/^[a-zA-Z0-9_]+$/),
+            Validators.pattern(/^\w+$/),
           ],
         ],
         email: ['', [Validators.required, Validators.email]],
@@ -91,7 +91,7 @@ export class RegisterForm {
     this.auth.register({ username, email, password }).subscribe({
       next: () => {
         this.loading.set(false);
-        this.router.navigateByUrl('/dashboard');
+        this.router.navigateByUrl('/check-email');
       },
       error: (err: HttpErrorResponse) => {
         this.loading.set(false);

--- a/frontend/src/app/features/auth/components/reset-password-form/reset-password-form.html
+++ b/frontend/src/app/features/auth/components/reset-password-form/reset-password-form.html
@@ -1,0 +1,62 @@
+@if (!success()) {
+  <form class="reset-form" [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+
+    <div class="field">
+      <label class="field-label" for="rp-new">Nueva contraseña</label>
+      <div class="input-wrap">
+        <input
+          id="rp-new"
+          [type]="showPw() ? 'text' : 'password'"
+          class="vs-input"
+          [class.vs-input--error]="isInvalid('newPassword')"
+          formControlName="newPassword"
+          placeholder="Mínimo 8 caracteres"
+          autocomplete="new-password"
+        />
+        <button type="button" class="eye-btn" (click)="showPw.update(v => !v)" tabindex="-1">
+          {{ showPw() ? '🙈' : '👁' }}
+        </button>
+      </div>
+      @if (isInvalid('newPassword')) {
+        <span class="field-error">{{ getError('newPassword') }}</span>
+      }
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="rp-confirm">Confirmar contraseña</label>
+      <div class="input-wrap">
+        <input
+          id="rp-confirm"
+          [type]="showCpw() ? 'text' : 'password'"
+          class="vs-input"
+          [class.vs-input--error]="isInvalid('confirmPassword') || mismatch"
+          formControlName="confirmPassword"
+          placeholder="Repite la contraseña"
+          autocomplete="new-password"
+        />
+        <button type="button" class="eye-btn" (click)="showCpw.update(v => !v)" tabindex="-1">
+          {{ showCpw() ? '🙈' : '👁' }}
+        </button>
+      </div>
+      @if (mismatch) {
+        <span class="field-error">Las contraseñas no coinciden</span>
+      }
+      @if (isInvalid('confirmPassword') && !mismatch) {
+        <span class="field-error">{{ getError('confirmPassword') }}</span>
+      }
+    </div>
+
+    @if (errorMessage()) {
+      <p class="form-error">{{ errorMessage() }}</p>
+    }
+
+    <app-vs-button type="submit" variant="primary" [loading]="loading()" [block]="true">
+      Guardar nueva contraseña
+    </app-vs-button>
+  </form>
+} @else {
+  <div class="success-msg">
+    <span class="success-icon">✅</span>
+    <p>¡Contraseña actualizada! Redirigiendo al login...</p>
+  </div>
+}

--- a/frontend/src/app/features/auth/components/reset-password-form/reset-password-form.scss
+++ b/frontend/src/app/features/auth/components/reset-password-form/reset-password-form.scss
@@ -1,0 +1,70 @@
+.reset-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--vs-text-secondary);
+}
+
+.input-wrap {
+  position: relative;
+
+  .vs-input {
+    width: 100%;
+    padding-right: 44px;
+    box-sizing: border-box;
+  }
+}
+
+.eye-btn {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0;
+  line-height: 1;
+}
+
+.field-error {
+  font-size: 12px;
+  color: var(--vs-accent-red);
+}
+
+.form-error {
+  font-size: 13px;
+  color: var(--vs-accent-red);
+  text-align: center;
+  margin: 0;
+}
+
+.success-msg {
+  text-align: center;
+  padding: 16px 0;
+
+  .success-icon {
+    font-size: 48px;
+    display: block;
+    margin-bottom: 16px;
+  }
+
+  p {
+    font-size: 15px;
+    color: var(--vs-text-secondary);
+    line-height: 1.7;
+    margin: 0;
+  }
+}

--- a/frontend/src/app/features/auth/components/reset-password-form/reset-password-form.ts
+++ b/frontend/src/app/features/auth/components/reset-password-form/reset-password-form.ts
@@ -1,0 +1,89 @@
+import { Component, Input, OnInit, inject, signal } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AuthService } from '../../../../core/services/auth.service';
+import { VsButtonComponent } from '../../../../shared/components/vs-button/vs-button.component';
+
+function passwordMatchValidator(group: AbstractControl): ValidationErrors | null {
+  const pw  = group.get('newPassword')?.value;
+  const cpw = group.get('confirmPassword')?.value;
+  return pw && cpw && pw !== cpw ? { passwordMismatch: true } : null;
+}
+
+@Component({
+  selector: 'app-reset-password-form',
+  imports: [ReactiveFormsModule, VsButtonComponent],
+  templateUrl: './reset-password-form.html',
+  styleUrl: './reset-password-form.scss',
+})
+export class ResetPasswordForm implements OnInit {
+  @Input({ required: true }) token!: string;
+
+  readonly loading  = signal(false);
+  readonly success  = signal(false);
+  readonly showPw   = signal(false);
+  readonly showCpw  = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly form = inject(FormBuilder).group(
+    {
+      newPassword:     ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
+      confirmPassword: ['', Validators.required],
+    },
+    { validators: passwordMatchValidator },
+  );
+
+  private readonly auth   = inject(AuthService);
+  private readonly router = inject(Router);
+
+  ngOnInit(): void {
+    if (!this.token) {
+      this.errorMessage.set('No se encontró el token de recuperación en el enlace.');
+    }
+  }
+
+  isInvalid(field: string): boolean {
+    const ctrl = this.form.get(field);
+    return !!(ctrl?.invalid && ctrl.touched);
+  }
+
+  getError(field: string): string | null {
+    const ctrl = this.form.get(field);
+    if (!ctrl?.errors || !ctrl.touched) return null;
+    const { required, minlength, maxlength } = ctrl.errors;
+    if (required)   return 'Este campo es obligatorio';
+    if (minlength)  return `Mínimo ${minlength.requiredLength} caracteres`;
+    if (maxlength)  return `Máximo ${maxlength.requiredLength} caracteres`;
+    return null;
+  }
+
+  get mismatch(): boolean {
+    return !!(this.form.hasError('passwordMismatch') && this.form.get('confirmPassword')?.touched);
+  }
+
+  onSubmit(): void {
+    this.form.markAllAsTouched();
+    if (this.form.invalid || this.loading() || !this.token) return;
+
+    this.errorMessage.set(null);
+    this.loading.set(true);
+
+    const { newPassword } = this.form.value;
+    this.auth.confirmPasswordReset({ token: this.token, newPassword: newPassword! }).subscribe({
+      next: () => {
+        this.loading.set(false);
+        this.success.set(true);
+        setTimeout(() => this.router.navigateByUrl('/login'), 2500);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.loading.set(false);
+        const code = err?.error?.error;
+        if (code === 'TOKEN_EXPIRED')  this.errorMessage.set('El enlace ha expirado. Solicita uno nuevo.');
+        else if (code === 'TOKEN_INVALID') this.errorMessage.set('El enlace no es válido.');
+        else if (err.status === 0) this.errorMessage.set('No se puede conectar con el servidor');
+        else this.errorMessage.set(err?.error?.message ?? 'Error inesperado');
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/auth/pages/check-email/check-email.html
+++ b/frontend/src/app/features/auth/pages/check-email/check-email.html
@@ -1,0 +1,17 @@
+<div class="vs-screen">
+  <div class="check-card vs-card animate-in">
+    <div class="icon">✉</div>
+    <h1 class="vs-display check-title">REVISA TU CORREO</h1>
+    <p class="check-msg">
+      Te hemos enviado un enlace de verificación. Por favor, abre tu bandeja de entrada y haz clic en el enlace para activar tu cuenta.
+    </p>
+    <p class="check-note">
+      Si no ves el correo, revisa la carpeta de spam.
+    </p>
+    <hr class="vs-divider" />
+    <p class="login-prompt">
+      ¿Ya verificaste tu cuenta?
+      <a routerLink="/login" class="login-link">Inicia sesión</a>
+    </p>
+  </div>
+</div>

--- a/frontend/src/app/features/auth/pages/check-email/check-email.scss
+++ b/frontend/src/app/features/auth/pages/check-email/check-email.scss
@@ -1,0 +1,48 @@
+.check-card {
+  width: 100%;
+  max-width: 440px;
+  padding: 48px 40px;
+  text-align: center;
+}
+
+.icon {
+  font-size: 56px;
+  margin-bottom: 16px;
+  line-height: 1;
+}
+
+.check-title {
+  font-size: 36px;
+  color: var(--vs-text-primary);
+  margin: 0 0 20px;
+}
+
+.check-msg {
+  font-size: 15px;
+  color: var(--vs-text-secondary);
+  line-height: 1.7;
+  margin: 0 0 12px;
+}
+
+.check-note {
+  font-size: 13px;
+  color: var(--vs-text-muted);
+  margin: 0 0 24px;
+}
+
+.login-prompt {
+  font-size: 14px;
+  color: var(--vs-text-secondary);
+  margin: 0;
+}
+
+.login-link {
+  color: var(--vs-accent-blue);
+  text-decoration: none;
+  font-weight: 600;
+  transition: opacity var(--vs-transition);
+
+  &:hover {
+    opacity: 0.8;
+  }
+}

--- a/frontend/src/app/features/auth/pages/check-email/check-email.ts
+++ b/frontend/src/app/features/auth/pages/check-email/check-email.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-check-email',
+  imports: [RouterLink],
+  templateUrl: './check-email.html',
+  styleUrl: './check-email.scss',
+})
+export class CheckEmail {}

--- a/frontend/src/app/features/auth/pages/forgot-password/forgot-password.html
+++ b/frontend/src/app/features/auth/pages/forgot-password/forgot-password.html
@@ -1,0 +1,17 @@
+<div class="vs-screen">
+  <div class="forgot-card vs-card animate-in">
+    <header class="forgot-header">
+      <h1 class="vs-display forgot-title">VERSUS</h1>
+      <p class="forgot-subtitle">Recupera el acceso a tu cuenta</p>
+    </header>
+
+    <app-forgot-password-form />
+
+    <hr class="vs-divider" />
+
+    <p class="back-prompt">
+      ¿Recordaste tu contraseña?
+      <a routerLink="/login" class="back-link">Inicia sesión</a>
+    </p>
+  </div>
+</div>

--- a/frontend/src/app/features/auth/pages/forgot-password/forgot-password.scss
+++ b/frontend/src/app/features/auth/pages/forgot-password/forgot-password.scss
@@ -1,0 +1,40 @@
+.forgot-card {
+  width: 100%;
+  max-width: 400px;
+  padding: 40px;
+}
+
+.forgot-header {
+  text-align: center;
+  margin-bottom: 36px;
+}
+
+.forgot-title {
+  font-size: 64px;
+  color: var(--vs-text-primary);
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.forgot-subtitle {
+  font-size: 14px;
+  color: var(--vs-text-secondary);
+}
+
+.back-prompt {
+  text-align: center;
+  font-size: 14px;
+  color: var(--vs-text-secondary);
+  margin: 0;
+}
+
+.back-link {
+  color: var(--vs-accent-blue);
+  text-decoration: none;
+  font-weight: 600;
+  transition: opacity var(--vs-transition);
+
+  &:hover {
+    opacity: 0.8;
+  }
+}

--- a/frontend/src/app/features/auth/pages/forgot-password/forgot-password.ts
+++ b/frontend/src/app/features/auth/pages/forgot-password/forgot-password.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ForgotPasswordForm } from '../../components/forgot-password-form/forgot-password-form';
+
+@Component({
+  selector: 'app-forgot-password',
+  imports: [RouterLink, ForgotPasswordForm],
+  templateUrl: './forgot-password.html',
+  styleUrl: './forgot-password.scss',
+})
+export class ForgotPassword {}

--- a/frontend/src/app/features/auth/pages/reset-password/reset-password.html
+++ b/frontend/src/app/features/auth/pages/reset-password/reset-password.html
@@ -1,0 +1,23 @@
+<div class="vs-screen">
+  <div class="reset-card vs-card animate-in">
+    <header class="reset-header">
+      <h1 class="vs-display reset-title">VERSUS</h1>
+      <p class="reset-subtitle">Elige una nueva contraseña</p>
+    </header>
+
+    @if (token()) {
+      <app-reset-password-form [token]="token()" />
+    } @else {
+      <div class="no-token">
+        <p>El enlace de recuperación no es válido o ha expirado.</p>
+        <a routerLink="/forgot-password" class="retry-link">Solicitar un nuevo enlace</a>
+      </div>
+    }
+
+    <hr class="vs-divider" />
+
+    <p class="back-prompt">
+      <a routerLink="/login" class="back-link">Volver al login</a>
+    </p>
+  </div>
+</div>

--- a/frontend/src/app/features/auth/pages/reset-password/reset-password.scss
+++ b/frontend/src/app/features/auth/pages/reset-password/reset-password.scss
@@ -1,0 +1,56 @@
+.reset-card {
+  width: 100%;
+  max-width: 400px;
+  padding: 40px;
+}
+
+.reset-header {
+  text-align: center;
+  margin-bottom: 36px;
+}
+
+.reset-title {
+  font-size: 64px;
+  color: var(--vs-text-primary);
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.reset-subtitle {
+  font-size: 14px;
+  color: var(--vs-text-secondary);
+}
+
+.no-token {
+  text-align: center;
+  padding: 12px 0 24px;
+
+  p {
+    font-size: 15px;
+    color: var(--vs-text-secondary);
+    margin: 0 0 16px;
+  }
+}
+
+.retry-link {
+  color: var(--vs-accent-blue);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 14px;
+
+  &:hover { opacity: 0.8; }
+}
+
+.back-prompt {
+  text-align: center;
+  margin: 0;
+}
+
+.back-link {
+  font-size: 14px;
+  color: var(--vs-text-secondary);
+  text-decoration: none;
+  transition: opacity var(--vs-transition);
+
+  &:hover { opacity: 0.8; }
+}

--- a/frontend/src/app/features/auth/pages/reset-password/reset-password.ts
+++ b/frontend/src/app/features/auth/pages/reset-password/reset-password.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ResetPasswordForm } from '../../components/reset-password-form/reset-password-form';
+
+@Component({
+  selector: 'app-reset-password',
+  imports: [RouterLink, ResetPasswordForm],
+  templateUrl: './reset-password.html',
+  styleUrl: './reset-password.scss',
+})
+export class ResetPassword implements OnInit {
+  readonly token = signal<string>('');
+
+  private readonly route = inject(ActivatedRoute);
+
+  ngOnInit(): void {
+    this.token.set(this.route.snapshot.queryParamMap.get('token') ?? '');
+  }
+}

--- a/frontend/src/app/features/auth/pages/verify-email/verify-email.html
+++ b/frontend/src/app/features/auth/pages/verify-email/verify-email.html
@@ -1,0 +1,32 @@
+<div class="vs-screen">
+  <div class="verify-card vs-card animate-in">
+
+    @if (state() === 'loading') {
+      <div class="icon spin">⏳</div>
+      <h1 class="vs-display verify-title">VERIFICANDO</h1>
+      <p class="verify-msg">Estamos activando tu cuenta, por favor espera...</p>
+    }
+
+    @if (state() === 'success') {
+      <div class="icon">✅</div>
+      <h1 class="vs-display verify-title success">¡CUENTA ACTIVADA!</h1>
+      <p class="verify-msg">{{ message() }}</p>
+      <a routerLink="/login" class="vs-btn btn-primary">Iniciar sesión</a>
+    }
+
+    @if (state() === 'expired') {
+      <div class="icon">⌛</div>
+      <h1 class="vs-display verify-title error">ENLACE EXPIRADO</h1>
+      <p class="verify-msg">{{ message() }}</p>
+      <a routerLink="/register" class="vs-btn btn-secondary">Volver al registro</a>
+    }
+
+    @if (state() === 'invalid') {
+      <div class="icon">❌</div>
+      <h1 class="vs-display verify-title error">ENLACE INVÁLIDO</h1>
+      <p class="verify-msg">{{ message() }}</p>
+      <a routerLink="/login" class="vs-btn btn-secondary">Ir al login</a>
+    }
+
+  </div>
+</div>

--- a/frontend/src/app/features/auth/pages/verify-email/verify-email.scss
+++ b/frontend/src/app/features/auth/pages/verify-email/verify-email.scss
@@ -1,0 +1,62 @@
+.verify-card {
+  width: 100%;
+  max-width: 440px;
+  padding: 48px 40px;
+  text-align: center;
+}
+
+.icon {
+  font-size: 56px;
+  margin-bottom: 16px;
+  line-height: 1;
+
+  &.spin {
+    display: inline-block;
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+.verify-title {
+  font-size: 32px;
+  color: var(--vs-text-primary);
+  margin: 0 0 20px;
+
+  &.success { color: var(--vs-accent-green); }
+  &.error   { color: var(--vs-accent-red); }
+}
+
+.verify-msg {
+  font-size: 15px;
+  color: var(--vs-text-secondary);
+  line-height: 1.7;
+  margin: 0 0 28px;
+}
+
+.vs-btn {
+  display: inline-block;
+  padding: 13px 28px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  transition: opacity var(--vs-transition);
+
+  &:hover { opacity: 0.85; }
+
+  &.btn-primary {
+    background: var(--vs-accent-blue);
+    color: #fff;
+  }
+
+  &.btn-secondary {
+    background: transparent;
+    color: var(--vs-text-secondary);
+    border: 1px solid var(--vs-text-muted);
+  }
+}

--- a/frontend/src/app/features/auth/pages/verify-email/verify-email.ts
+++ b/frontend/src/app/features/auth/pages/verify-email/verify-email.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { AuthService } from '../../../../core/services/auth.service';
+import { HttpErrorResponse } from '@angular/common/http';
+
+@Component({
+  selector: 'app-verify-email',
+  imports: [RouterLink],
+  templateUrl: './verify-email.html',
+  styleUrl: './verify-email.scss',
+})
+export class VerifyEmail implements OnInit {
+  readonly state = signal<'loading' | 'success' | 'expired' | 'invalid'>('loading');
+  readonly message = signal<string | null>(null);
+
+  private readonly route = inject(ActivatedRoute);
+  private readonly auth = inject(AuthService);
+
+  ngOnInit(): void {
+    const token = this.route.snapshot.queryParamMap.get('token');
+    if (!token) {
+      this.state.set('invalid');
+      this.message.set('No se encontró el token de verificación en el enlace.');
+      return;
+    }
+    this.auth.verifyEmail(token).subscribe({
+      next: (res) => {
+        this.state.set('success');
+        this.message.set(res.message);
+      },
+      error: (err: HttpErrorResponse) => {
+        const code = err?.error?.error;
+        if (code === 'TOKEN_EXPIRED') {
+          this.state.set('expired');
+          this.message.set('El enlace de verificación ha expirado. Vuelve a registrarte para recibir uno nuevo.');
+        } else {
+          this.state.set('invalid');
+          this.message.set('El enlace de verificación no es válido.');
+        }
+      },
+    });
+  }
+}

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -1,18 +1,20 @@
-FROM python:3.12-alpine
+FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-# Alpine usa apk, mucho más ligero y sin los problemas de los mirrors de Debian
-RUN apk add --no-cache \
+# scrapy-playwright depends on Playwright wheels, which are not available for
+# Alpine/musl. Debian slim keeps the image reasonably small and compatible.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
-    musl-dev \
-    libxml2-dev \
-    libxslt-dev \
     libffi-dev \
-    openssl-dev
+    libpq-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Backend:
- EmailService con JavaMailSender + Thymeleaf (verificacion y reset)
- AsyncConfig con ThreadPoolTaskExecutor dedicado y AsyncUncaughtExceptionHandler
- User: campos enabled, verificationToken/Expiry, passwordResetToken/Expiry
- AuthService: registro devuelve MessageResponse, login bloquea no verificados
- Endpoints: GET /api/auth/verify, POST /api/auth/password-reset/request y /confirm
- SecurityConfig: permite GET /api/auth/verify sin autenticacion
- Templates Thymeleaf: email/verification.html y email/password-reset.html
- docker-compose.dev.yml: MailHog como SMTP mock, vars SMTP leidas del .env

Frontend:
- Rutas lazy: /check-email, /verify-email, /forgot-password, /reset-password
- Paginas: CheckEmail, VerifyEmail, ForgotPassword, ResetPassword
- Componentes: ForgotPasswordForm, ResetPasswordForm
- AuthService: metodos verifyEmail, requestPasswordReset, confirmPasswordReset
- LoginForm: enlace a /forgot-password
- RegisterForm: redirige a /check-email tras registro exitoso