### PR TITLE
Issue 107 notification center

### DIFF
--- a/docs/backend/modules/achievements.md
+++ b/docs/backend/modules/achievements.md
@@ -40,5 +40,6 @@ Los logros bloqueados se devuelven con `name`, `description` e `iconKey` ocultos
 ## Frontend asociado
 
 - Toast global al desbloquear un logro.
+- Centro de notificaciones en tiempo real: `NotificationCenterService` escucha `/user/queue/achievements`, registra el evento como notificacion local y respeta `vs.notificationPrefs.achievements`.
 - Grid `Logros` en perfil con contador `desbloqueados/total`.
 - Emblema del logro mas reciente sobre el avatar del topbar.

--- a/docs/backend/modules/websocket.md
+++ b/docs/backend/modules/websocket.md
@@ -153,6 +153,7 @@ Si el token falta, no es Bearer, está caducado, está firmado con otra clave o 
 |---|---|---|
 | `/app/*` | Mensajes que el **cliente envía al servidor** (despacha a `@MessageMapping`). | `/app/match/answer`, `/app/match/ready` |
 | `/topic/*` | Broadcast a todos los suscriptores. | `/topic/match/{matchId}` (estado compartido) |
+| `/user/queue/achievements` | Mensaje privado de logros desbloqueados para el usuario autenticado. | `ACHIEVEMENT_UNLOCKED` |
 | `/user/queue/*` | Mensaje **privado** dirigido a un usuario concreto. Spring resuelve `{userId}` desde el `Principal` autenticado. | `/user/queue/match` (notificaciones tipo "te tocó pareja") |
 
 Reglas:
@@ -207,6 +208,17 @@ Características:
 - `publish()` no encola: si no estás conectado, el mensaje se descarta y se loguea un warning. Es responsabilidad del caller llamar `connect()` antes.
 
 URL base configurable en `frontend/src/environments/environment.ts → wsUrl`.
+
+### Centro de notificaciones Angular
+
+`NotificationCenterService` reutiliza `WebSocketService` para mantener un centro de notificaciones transversal en el topbar.
+
+| Canal | Payload | Uso |
+|---|---|---|
+| `/user/queue/match` | `MatchEventEnvelope<MATCH_FOUND>` | Crea una notificacion "Rival encontrado" y enlaza a `/play/lobby/:matchId`. |
+| `/user/queue/achievements` | `{ type: "ACHIEVEMENT_UNLOCKED", achievement }` | Crea una notificacion de logro y enlaza a `/profile`. |
+
+El cliente persiste el historial en `localStorage` por usuario (`vs.notifications.<userId>`) y limita el listado a 30 elementos. Las preferencias de `/settings` se leen de `vs.notificationPrefs`; `matchInvites=false` bloquea eventos `MATCH_FOUND` y `achievements=false` bloquea entradas/toasts de logros.
 
 ---
 

--- a/docs/frontend/arquitectura.md
+++ b/docs/frontend/arquitectura.md
@@ -90,6 +90,35 @@ El estado se inicializa leyendo `localStorage` al arrancar (`vs.accessToken`, `v
 | `QuestionService` | Preguntas aleatorias con filtros | — |
 | `StatsService` | Estadísticas del jugador | — |
 | `WebSocketService` | Conexión STOMP + eventos de partida | (pendiente Sprint 3) |
+| `NotificationCenterService` | Centro de notificaciones en tiempo real | `items`, `unreadCount` |
+
+## Centro de notificaciones en tiempo real
+
+El centro de notificaciones vive en el `TopbarComponent` y se alimenta desde `NotificationCenterService`.
+
+Ficheros principales:
+
+| Fichero | Responsabilidad |
+|---|---|
+| `core/models/notification.models.ts` | Tipos `NotificationItem`, preferencias y claves de `localStorage`. |
+| `core/services/notification-center.service.ts` | Suscripciones STOMP, normalizacion de eventos, persistencia local y estado de lectura. |
+| `shared/components/layout/topbar/*` | Boton de campana, contador, panel desplegable y acciones de lectura. |
+
+Canales consumidos:
+
+| Canal | Evento | Resultado en UI |
+|---|---|---|
+| `/user/queue/achievements` | `ACHIEVEMENT_UNLOCKED` | Notificacion de logro, ruta a `/profile` y toast global si esta permitido. |
+| `/user/queue/match` | `MATCH_FOUND` | Notificacion de rival encontrado, ruta a `/play/lobby/:matchId`. |
+
+Persistencia y preferencias:
+
+- Las notificaciones se guardan por usuario en `localStorage` con clave `vs.notifications.<userId>`.
+- El historial se limita a las ultimas 30 notificaciones.
+- Las preferencias viven en `vs.notificationPrefs` y se editan desde `/settings`.
+- `achievements=false` desactiva tanto el toast global como la entrada en el centro.
+- `matchInvites=false` oculta las notificaciones de `MATCH_FOUND`.
+- Si cambia el usuario autenticado, el servicio reconecta el WebSocket para evitar reutilizar una sesion STOMP anterior.
 
 ## AuthInterceptor
 

--- a/docs/guia-de-coordinación-técnica.md
+++ b/docs/guia-de-coordinación-técnica.md
@@ -160,6 +160,7 @@ Respuesta: `204 No Content`. En frontend se exige doble confirmacion escribiendo
 - Password: requiere password actual y confirmacion visual en el formulario.
 - Avatar: galeria de avatares predefinidos con confirmacion `Aceptar/Cancelar`; upload PNG/JPEG con crop basico y boton de subida.
 - Notificaciones: preferencias de solicitudes de amistad, invitaciones y logros guardadas en `localStorage`.
+- Centro de notificaciones: desplegable en el topbar con contador de no leidas, historial local por usuario (`vs.notifications.<userId>`) y acciones de marcar leidas/vaciar.
 - Audio: controles `Efectos de sonido`, `Musica de fondo`, silenciar todo y feedback reducido guardados en `localStorage`.
 - Zona de peligro: borrar cuenta exige escribir el username.
 - Topbar: muestra username/avatar reales y XP calculado desde `/api/stats/me` mientras no exista campo `xp` dedicado.
@@ -320,6 +321,7 @@ Frontend conecta a:  ws://localhost:8080/ws  (STOMP sobre SockJS)
 Auth: header CONNECT  Authorization: Bearer <jwt>
  
 Suscripciones del cliente:
+  /user/queue/achievements   -> logros desbloqueados (ACHIEVEMENT_UNLOCKED)
   /user/queue/match          → notificaciones privadas (MATCH_FOUND)
   /topic/match/{matchId}     → estado compartido del lobby/partida
  
@@ -474,6 +476,7 @@ Si un logro esta bloqueado, el backend devuelve `name: "???"`, `description: "??
 ### Frontend
 
 - Toast global no bloqueante al desbloquear un logro.
+- Centro de notificaciones: registra logros desbloqueados en tiempo real, respeta `vs.notificationPrefs.achievements` y enlaza a `/profile`.
 - Perfil: seccion `Logros` con contador `desbloqueados/total`, grid de catalogo y fecha si esta desbloqueado.
 - Topbar/avatar: muestra como emblema el logro desbloqueado mas reciente.
  

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,7 @@
 - `/settings`: pagina centralizada para editar username, password, avatar, notificaciones, audio y eliminar cuenta.
 - Avatar: galeria predefinida con confirmacion, upload PNG/JPEG con crop basico y limite de 2MB.
 - Topbar: muestra username/avatar reales y XP derivado de `player_stats` hasta tener un campo `xp` dedicado.
+- Centro de notificaciones: campana en topbar con eventos en tiempo real de logros y matchmaking, historial local por usuario y contador de no leidas.
 - Cuenta: soft delete con `status=DELETED`, `is_active=false` y anonimizacion de datos.
 - Logros: catalogo inicial, desbloqueo al terminar partida, toast global, grid en perfil y emblema reciente en el avatar.
 

--- a/frontend/src/app/core/models/notification.models.ts
+++ b/frontend/src/app/core/models/notification.models.ts
@@ -1,0 +1,32 @@
+export type NotificationTone = 'info' | 'success' | 'warning' | 'danger';
+
+export type NotificationType =
+  | 'ACHIEVEMENT_UNLOCKED'
+  | 'MATCH_FOUND'
+  | 'SYSTEM';
+
+export interface NotificationItem {
+  id: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  createdAt: string;
+  read: boolean;
+  tone: NotificationTone;
+  route?: string;
+  sourceId?: string;
+}
+
+export interface NotificationPrefs {
+  friendRequests: boolean;
+  matchInvites: boolean;
+  achievements: boolean;
+}
+
+export const NOTIFICATION_PREFS_KEY = 'vs.notificationPrefs';
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
+  friendRequests: true,
+  matchInvites: true,
+  achievements: true,
+};

--- a/frontend/src/app/core/services/achievement-toast.service.ts
+++ b/frontend/src/app/core/services/achievement-toast.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, signal } from '@angular/core';
 import { Achievement } from '../models/achievement.models';
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  NOTIFICATION_PREFS_KEY,
+} from '../models/notification.models';
 
 export interface AchievementToast {
   id: number;
@@ -21,6 +25,7 @@ export class AchievementToastService {
 
   show(achievement: Achievement): void {
     if (!achievement.unlocked) return;
+    if (!this.achievementNotificationsEnabled()) return;
 
     const now = Date.now();
     const lastSeen = this.recentKeys.get(achievement.key);
@@ -34,5 +39,15 @@ export class AchievementToastService {
 
   dismiss(id: number): void {
     this.items.update((items) => items.filter((item) => item.id !== id));
+  }
+
+  private achievementNotificationsEnabled(): boolean {
+    const raw = localStorage.getItem(NOTIFICATION_PREFS_KEY);
+    if (!raw) return DEFAULT_NOTIFICATION_PREFS.achievements;
+    try {
+      return { ...DEFAULT_NOTIFICATION_PREFS, ...JSON.parse(raw) }.achievements;
+    } catch {
+      return DEFAULT_NOTIFICATION_PREFS.achievements;
+    }
   }
 }

--- a/frontend/src/app/core/services/notification-center.service.spec.ts
+++ b/frontend/src/app/core/services/notification-center.service.spec.ts
@@ -1,0 +1,168 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { EMPTY, Subject } from 'rxjs';
+import type { Achievement, AchievementUnlockedEvent } from '../models/achievement.models';
+import type { AuthUser } from '../models/auth.models';
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  NOTIFICATION_PREFS_KEY,
+} from '../models/notification.models';
+import type { MatchEvent } from '../models/ws.models';
+import { AchievementToastService } from './achievement-toast.service';
+import { AuthService } from './auth.service';
+import { NotificationCenterService } from './notification-center.service';
+import { WebSocketService } from './websocket.service';
+
+describe('NotificationCenterService', () => {
+  let service: NotificationCenterService;
+  let achievementEvents: Subject<AchievementUnlockedEvent>;
+  let matchEvents: Subject<MatchEvent<unknown>>;
+  let toastService: { show: ReturnType<typeof vi.fn> };
+  let webSocketService: {
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
+  };
+
+  const authUser = signal<AuthUser | null>({
+    id: 'user-1',
+    username: 'player',
+    role: 'PLAYER',
+    avatarUrl: null,
+  });
+
+  const achievement: Achievement = {
+    id: 'achievement-1',
+    key: 'first_game',
+    name: 'Primeros pasos',
+    description: 'Juega tu primera partida.',
+    iconKey: 'first',
+    category: 'Primeros pasos',
+    unlocked: true,
+    unlockedAt: '2026-01-02T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    authUser.set({
+      id: 'user-1',
+      username: 'player',
+      role: 'PLAYER',
+      avatarUrl: null,
+    });
+    achievementEvents = new Subject<AchievementUnlockedEvent>();
+    matchEvents = new Subject<MatchEvent<unknown>>();
+    toastService = { show: vi.fn() };
+    webSocketService = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      subscribe: vi.fn((destination: string) => {
+        if (destination === '/user/queue/achievements') return achievementEvents.asObservable();
+        if (destination === '/user/queue/match') return matchEvents.asObservable();
+        return EMPTY;
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationCenterService,
+        {
+          provide: AuthService,
+          useValue: {
+            user: authUser,
+          },
+        },
+        {
+          provide: AchievementToastService,
+          useValue: toastService,
+        },
+        {
+          provide: WebSocketService,
+          useValue: webSocketService,
+        },
+      ],
+    });
+
+    service = TestBed.inject(NotificationCenterService);
+  });
+
+  it('should add realtime achievement notifications once and show toast', () => {
+    service.start();
+
+    achievementEvents.next({ type: 'ACHIEVEMENT_UNLOCKED', achievement });
+    achievementEvents.next({ type: 'ACHIEVEMENT_UNLOCKED', achievement });
+
+    expect(service.items()).toHaveLength(1);
+    expect(service.unreadCount()).toBe(1);
+    expect(service.items()[0].message).toBe('Primeros pasos');
+    expect(toastService.show).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorage.getItem('vs.notifications.user-1') ?? '[]')).toHaveLength(1);
+  });
+
+  it('should add match found notifications when match invites are enabled', () => {
+    service.start();
+
+    matchEvents.next({
+      type: 'MATCH_FOUND',
+      matchId: 'match-1',
+      payload: {
+        matchId: 'match-1',
+        mode: 'BINARY_DUEL',
+        opponents: [{ userId: 'user-2', username: 'rival', avatarUrl: null, ready: false }],
+      },
+    });
+
+    expect(service.items()).toHaveLength(1);
+    expect(service.items()[0].title).toBe('Rival encontrado');
+    expect(service.items()[0].route).toBe('/play/lobby/match-1');
+  });
+
+  it('should ignore disabled notification categories', () => {
+    localStorage.setItem(NOTIFICATION_PREFS_KEY, JSON.stringify({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      achievements: false,
+      matchInvites: false,
+    }));
+
+    service.start();
+    achievementEvents.next({ type: 'ACHIEVEMENT_UNLOCKED', achievement });
+    matchEvents.next({
+      type: 'MATCH_FOUND',
+      matchId: 'match-1',
+      payload: {
+        matchId: 'match-1',
+        mode: 'BINARY_DUEL',
+        opponents: [],
+      },
+    });
+
+    expect(service.items()).toEqual([]);
+    expect(toastService.show).not.toHaveBeenCalled();
+  });
+
+  it('should mark and clear notifications', () => {
+    service.addAchievements([achievement]);
+
+    const id = service.items()[0].id;
+    service.markRead(id);
+    expect(service.items()[0].read).toBe(true);
+
+    service.clear();
+    expect(service.items()).toEqual([]);
+  });
+
+  it('should reconnect websocket when the authenticated user changes', () => {
+    service.start();
+
+    authUser.set({
+      id: 'user-2',
+      username: 'other',
+      role: 'PLAYER',
+      avatarUrl: null,
+    });
+    service.start();
+
+    expect(webSocketService.disconnect).toHaveBeenCalledTimes(1);
+    expect(webSocketService.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/app/core/services/notification-center.service.ts
+++ b/frontend/src/app/core/services/notification-center.service.ts
@@ -1,0 +1,196 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { Subscription } from 'rxjs';
+import type { Achievement, AchievementUnlockedEvent } from '../models/achievement.models';
+import { MODE_LABELS } from '../models/match.models';
+import type { MatchFoundPayload } from '../models/match.models';
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  NOTIFICATION_PREFS_KEY,
+  type NotificationItem,
+  type NotificationPrefs,
+} from '../models/notification.models';
+import type { MatchEvent } from '../models/ws.models';
+import { AuthService } from './auth.service';
+import { AchievementToastService } from './achievement-toast.service';
+import { WebSocketService } from './websocket.service';
+
+const MAX_NOTIFICATIONS = 30;
+
+@Injectable({ providedIn: 'root' })
+export class NotificationCenterService {
+  private readonly auth = inject(AuthService);
+  private readonly ws = inject(WebSocketService);
+  private readonly achievementToasts = inject(AchievementToastService);
+
+  private readonly _items = signal<NotificationItem[]>([]);
+  private subscriptions = new Subscription();
+  private currentUserId: string | null = null;
+  private nextId = 1;
+  private started = false;
+
+  readonly items = this._items.asReadonly();
+  readonly unreadCount = computed(() => this._items().filter((item) => !item.read).length);
+
+  start(): void {
+    const user = this.auth.user();
+    if (!user) return;
+
+    if (this.started && this.currentUserId === user.id) return;
+    const userChanged = this.currentUserId !== null && this.currentUserId !== user.id;
+    this.stop(userChanged);
+
+    this.currentUserId = user.id;
+    this._items.set(this.readStored(user.id));
+    this.ws.connect();
+    this.subscriptions.add(
+      this.ws
+        .subscribe<AchievementUnlockedEvent>('/user/queue/achievements')
+        .subscribe((event) => this.handleAchievement(event)),
+    );
+    this.subscriptions.add(
+      this.ws
+        .subscribe<MatchEvent<unknown>>('/user/queue/match')
+        .subscribe((event) => this.handleMatch(event)),
+    );
+    this.started = true;
+  }
+
+  stop(disconnect = true): void {
+    this.subscriptions.unsubscribe();
+    this.subscriptions = new Subscription();
+    this.started = false;
+    this.currentUserId = null;
+    if (disconnect) {
+      this.ws.disconnect();
+    }
+  }
+
+  addAchievements(achievements: Achievement[] | null | undefined): void {
+    for (const achievement of achievements ?? []) {
+      this.addAchievement(achievement);
+    }
+  }
+
+  markRead(id: string): void {
+    this.updateItems((items) =>
+      items.map((item) => (item.id === id ? { ...item, read: true } : item)),
+    );
+  }
+
+  markAllRead(): void {
+    this.updateItems((items) => items.map((item) => ({ ...item, read: true })));
+  }
+
+  clear(): void {
+    this.updateItems(() => []);
+  }
+
+  private handleAchievement(event: AchievementUnlockedEvent): void {
+    if (event.type !== 'ACHIEVEMENT_UNLOCKED') return;
+    if (this.addAchievement(event.achievement)) {
+      this.achievementToasts.show(event.achievement);
+    }
+  }
+
+  private handleMatch(event: MatchEvent<unknown>): void {
+    if (event.type !== 'MATCH_FOUND') return;
+    if (!this.readPrefs().matchInvites) return;
+
+    const payload = event.payload as Partial<MatchFoundPayload>;
+    const mode = payload.mode ? MODE_LABELS[payload.mode] ?? payload.mode : 'partida';
+    const opponents = payload.opponents?.map((opponent) => opponent.username).filter(Boolean) ?? [];
+    const message = opponents.length > 0
+      ? `${opponents.join(', ')} te espera en ${mode}.`
+      : `Tu partida de ${mode} esta lista.`;
+
+    this.add({
+      type: 'MATCH_FOUND',
+      title: 'Rival encontrado',
+      message,
+      tone: 'info',
+      route: `/play/lobby/${event.matchId}`,
+      sourceId: `match-found:${event.matchId}`,
+    });
+  }
+
+  private addAchievement(achievement: Achievement): boolean {
+    if (!achievement.unlocked || !this.readPrefs().achievements) return false;
+    return this.add({
+      type: 'ACHIEVEMENT_UNLOCKED',
+      title: 'Logro desbloqueado',
+      message: achievement.name,
+      tone: 'success',
+      route: '/profile',
+      sourceId: `achievement:${achievement.key}`,
+    });
+  }
+
+  private add(item: Omit<NotificationItem, 'id' | 'createdAt' | 'read'>): boolean {
+    if (!this.ensureUserContext()) return false;
+
+    const sourceId = item.sourceId;
+    const exists = sourceId
+      ? this._items().some((current) => current.sourceId === sourceId && current.type === item.type)
+      : false;
+    if (exists) return false;
+
+    const next: NotificationItem = {
+      ...item,
+      id: this.createId(item.type),
+      createdAt: new Date().toISOString(),
+      read: false,
+    };
+    this.updateItems((items) => [next, ...items].slice(0, MAX_NOTIFICATIONS));
+    return true;
+  }
+
+  private updateItems(project: (items: NotificationItem[]) => NotificationItem[]): void {
+    const next = project(this._items());
+    this._items.set(next);
+    this.persist(next);
+  }
+
+  private createId(type: NotificationItem['type']): string {
+    return `${type.toLowerCase()}-${Date.now()}-${this.nextId++}`;
+  }
+
+  private storageKey(userId: string): string {
+    return `vs.notifications.${userId}`;
+  }
+
+  private ensureUserContext(): boolean {
+    const user = this.auth.user();
+    if (!user) return false;
+    if (this.currentUserId !== user.id) {
+      this.currentUserId = user.id;
+      this._items.set(this.readStored(user.id));
+    }
+    return true;
+  }
+
+  private readStored(userId: string): NotificationItem[] {
+    const raw = localStorage.getItem(this.storageKey(userId));
+    if (!raw) return [];
+    try {
+      const value = JSON.parse(raw) as NotificationItem[];
+      return Array.isArray(value) ? value.slice(0, MAX_NOTIFICATIONS) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private persist(items: NotificationItem[]): void {
+    if (!this.currentUserId) return;
+    localStorage.setItem(this.storageKey(this.currentUserId), JSON.stringify(items));
+  }
+
+  private readPrefs(): NotificationPrefs {
+    const raw = localStorage.getItem(NOTIFICATION_PREFS_KEY);
+    if (!raw) return DEFAULT_NOTIFICATION_PREFS;
+    try {
+      return { ...DEFAULT_NOTIFICATION_PREFS, ...JSON.parse(raw) };
+    } catch {
+      return DEFAULT_NOTIFICATION_PREFS;
+    }
+  }
+}

--- a/frontend/src/app/features/player/pages/settings/settings.spec.ts
+++ b/frontend/src/app/features/player/pages/settings/settings.spec.ts
@@ -8,6 +8,7 @@ import { AchievementService } from '../../../../core/services/achievement.servic
 import { UserService } from '../../../../core/services/user.service';
 import { StatsService } from '../../../../core/services/stats.service';
 import { audioService } from '../../../../core/services/AudioService';
+import { NotificationCenterService } from '../../../../core/services/notification-center.service';
 
 describe('Settings', () => {
   let component: Settings;
@@ -69,6 +70,17 @@ describe('Settings', () => {
         { provide: UserService, useValue: userService },
         { provide: StatsService, useValue: { mine: () => of([]) } },
         { provide: AchievementService, useValue: { list: () => of([]) } },
+        {
+          provide: NotificationCenterService,
+          useValue: {
+            items: signal([]),
+            unreadCount: signal(0),
+            start: vi.fn(),
+            markRead: vi.fn(),
+            markAllRead: vi.fn(),
+            clear: vi.fn(),
+          },
+        },
       ],
     }).compileComponents();
 

--- a/frontend/src/app/features/player/pages/settings/settings.ts
+++ b/frontend/src/app/features/player/pages/settings/settings.ts
@@ -7,11 +7,12 @@ import { AuthService } from '../../../../core/services/auth.service';
 import { UserService } from '../../../../core/services/user.service';
 import { UserMe } from '../../../../core/models/auth.models';
 import { AudioSettings, audioService } from '../../../../core/services/AudioService';
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  NOTIFICATION_PREFS_KEY,
+} from '../../../../core/models/notification.models';
 
 type AudioFormValue = { sfxEnabled: boolean; bgmEnabled: boolean; sfxVolume: number; bgmVolume: number };
-type NotificationPrefs = { friendRequests: boolean; matchInvites: boolean; achievements: boolean };
-
-const NOTIFICATION_KEY = 'vs.notificationPrefs';
 
 const DEFAULT_AUDIO_FORM: AudioFormValue = {
   sfxEnabled: true,
@@ -19,12 +20,6 @@ const DEFAULT_AUDIO_FORM: AudioFormValue = {
   sfxVolume: 80,
   bgmVolume: 40,
 };
-const DEFAULT_NOTIFICATIONS: NotificationPrefs = {
-  friendRequests: true,
-  matchInvites: true,
-  achievements: true,
-};
-
 @Component({
   selector: 'app-settings',
   standalone: true,
@@ -63,7 +58,7 @@ export class Settings implements OnInit {
     y: [0, [Validators.min(-50), Validators.max(50)]],
   });
 
-  readonly notificationsForm = this.fb.nonNullable.group(DEFAULT_NOTIFICATIONS);
+  readonly notificationsForm = this.fb.nonNullable.group(DEFAULT_NOTIFICATION_PREFS);
   readonly audioForm = this.fb.nonNullable.group(DEFAULT_AUDIO_FORM);
   readonly deleteForm = this.fb.nonNullable.group({ username: ['', Validators.required] });
 
@@ -98,11 +93,11 @@ export class Settings implements OnInit {
       error: () => this.error.set('No se pudo cargar tu cuenta.'),
     });
 
-    this.notificationsForm.patchValue(this.readPrefs(NOTIFICATION_KEY, DEFAULT_NOTIFICATIONS));
+    this.notificationsForm.patchValue(this.readPrefs(NOTIFICATION_PREFS_KEY, DEFAULT_NOTIFICATION_PREFS));
     this.audioForm.patchValue(this.toAudioForm(audioService.getSettings()), { emitEvent: false });
 
     this.notificationsForm.valueChanges.subscribe((value) =>
-      localStorage.setItem(NOTIFICATION_KEY, JSON.stringify(value))
+      localStorage.setItem(NOTIFICATION_PREFS_KEY, JSON.stringify(value))
     );
     this.audioForm.valueChanges.subscribe(() => this.applyAudioSettings());
   }

--- a/frontend/src/app/features/precision/pages/precision/precision.ts
+++ b/frontend/src/app/features/precision/pages/precision/precision.ts
@@ -3,6 +3,7 @@ import { Router, RouterLink } from '@angular/router';
 import { DecimalPipe } from '@angular/common';
 import { GameService } from '../../../../core/services/game.service';
 import { AchievementToastService } from '../../../../core/services/achievement-toast.service';
+import { NotificationCenterService } from '../../../../core/services/notification-center.service';
 import { NumericInputComponent } from '../../../../shared/components/ui/numeric-input/numeric-input';
 import { audioService } from '../../../../core/services/AudioService';
 import {
@@ -23,6 +24,7 @@ export class Precision implements OnInit, OnDestroy {
   private readonly game = inject(GameService);
   private readonly router = inject(Router);
   private readonly achievementToasts = inject(AchievementToastService);
+  private readonly notifications = inject(NotificationCenterService);
 
   @ViewChild(NumericInputComponent) private input?: NumericInputComponent;
 
@@ -119,6 +121,7 @@ export class Precision implements OnInit, OnDestroy {
     if (res.gameOver) {
       audioService.play('game_over');
       audioService.stopBgm();
+      this.notifications.addAchievements(res.achievementsUnlocked);
       this.achievementToasts.showMany(res.achievementsUnlocked);
       const finalRounds = this.rounds();
       setTimeout(

--- a/frontend/src/app/features/survival/pages/survival/survival.ts
+++ b/frontend/src/app/features/survival/pages/survival/survival.ts
@@ -3,6 +3,7 @@ import { Router, RouterLink } from '@angular/router';
 import { UpperCasePipe } from '@angular/common';
 import { GameService } from '../../../../core/services/game.service';
 import { AchievementToastService } from '../../../../core/services/achievement-toast.service';
+import { NotificationCenterService } from '../../../../core/services/notification-center.service';
 import { audioService } from '../../../../core/services/AudioService';
 import {
   QuestionBinary,
@@ -22,6 +23,7 @@ export class Survival implements OnInit, OnDestroy {
   private readonly game = inject(GameService);
   private readonly router = inject(Router);
   private readonly achievementToasts = inject(AchievementToastService);
+  private readonly notifications = inject(NotificationCenterService);
 
   lives  = signal(3);
   streak = signal(0);
@@ -168,6 +170,7 @@ export class Survival implements OnInit, OnDestroy {
     if (res.gameOver) {
       audioService.play('game_over');
       audioService.stopBgm();
+      this.notifications.addAchievements(res.achievementsUnlocked);
       this.achievementToasts.showMany(res.achievementsUnlocked);
       const finalScore = this.score();
       const finalStreak = this.streak();

--- a/frontend/src/app/shared/components/layout/topbar/topbar.html
+++ b/frontend/src/app/shared/components/layout/topbar/topbar.html
@@ -18,23 +18,126 @@
     }
   </nav>
 
-  <a class="vs-topbar__user" routerLink="/settings" title="Ajustes">
-    <div style="text-align: right">
-      <div style="font-weight: 600; font-size: 13px">{{ displayUser().name }}</div>
-      <div class="vs-mono" style="font-size: 11px; color: var(--vs-text-muted)">{{ displayUser().xp }} XP</div>
-    </div>
-    <div class="vs-avatar">
-      @if (displayUser().avatarUrl) {
-        <img [src]="displayUser().avatarUrl" alt="" />
-      } @else {
-        {{ initials() }}
+  <div class="vs-topbar__actions">
+    <div class="vs-notification-center" [class.is-open]="notificationsOpen()">
+      <button
+        type="button"
+        class="vs-icon-btn vs-notification-center__trigger"
+        aria-label="Abrir notificaciones"
+        [attr.aria-expanded]="notificationsOpen()"
+        (click)="toggleNotifications($event)"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18 16v-5a6 6 0 0 0-12 0v5l-2 3h16l-2-3Z" />
+          <path d="M10 21h4" />
+        </svg>
+        @if (unreadCount() > 0) {
+          <span class="vs-notification-center__badge">{{ unreadLabel() }}</span>
+        }
+      </button>
+
+      @if (notificationsOpen()) {
+        <section class="vs-notification-center__panel" aria-label="Centro de notificaciones">
+          <header class="vs-notification-center__head">
+            <div>
+              <div class="vs-section-title">Notificaciones</div>
+              <div class="vs-notification-center__count">{{ unreadCount() }} sin leer</div>
+            </div>
+            <div class="vs-notification-center__tools">
+              <button
+                type="button"
+                class="vs-icon-btn vs-icon-btn--sm"
+                aria-label="Marcar todas como leidas"
+                title="Marcar todas como leidas"
+                (click)="markAllNotificationsRead($event)"
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m4 12 5 5L20 6" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="vs-icon-btn vs-icon-btn--sm"
+                aria-label="Vaciar notificaciones"
+                title="Vaciar notificaciones"
+                (click)="clearNotifications($event)"
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M5 7h14" />
+                  <path d="M9 7V5h6v2" />
+                  <path d="m8 10 .5 9h7l.5-9" />
+                </svg>
+              </button>
+            </div>
+          </header>
+
+          @if (notificationItems().length === 0) {
+            <div class="vs-notification-center__empty">Sin notificaciones.</div>
+          } @else {
+            <div class="vs-notification-center__list vs-scroll">
+              @for (notification of notificationItems(); track notification.id) {
+                @if (notification.route) {
+                  <a
+                    class="vs-notification-item"
+                    [class.is-unread]="!notification.read"
+                    [class.tone-info]="notification.tone === 'info'"
+                    [class.tone-success]="notification.tone === 'success'"
+                    [class.tone-warning]="notification.tone === 'warning'"
+                    [class.tone-danger]="notification.tone === 'danger'"
+                    [routerLink]="notification.route"
+                    (click)="selectNotification(notification)"
+                  >
+                    <span class="vs-notification-item__icon">{{ notificationIcon(notification) }}</span>
+                    <span class="vs-notification-item__body">
+                      <span class="vs-notification-item__title">{{ notification.title }}</span>
+                      <span class="vs-notification-item__message">{{ notification.message }}</span>
+                      <span class="vs-notification-item__time">{{ notificationTime(notification) }}</span>
+                    </span>
+                  </a>
+                } @else {
+                  <button
+                    type="button"
+                    class="vs-notification-item"
+                    [class.is-unread]="!notification.read"
+                    [class.tone-info]="notification.tone === 'info'"
+                    [class.tone-success]="notification.tone === 'success'"
+                    [class.tone-warning]="notification.tone === 'warning'"
+                    [class.tone-danger]="notification.tone === 'danger'"
+                    (click)="selectNotification(notification)"
+                  >
+                    <span class="vs-notification-item__icon">{{ notificationIcon(notification) }}</span>
+                    <span class="vs-notification-item__body">
+                      <span class="vs-notification-item__title">{{ notification.title }}</span>
+                      <span class="vs-notification-item__message">{{ notification.message }}</span>
+                      <span class="vs-notification-item__time">{{ notificationTime(notification) }}</span>
+                    </span>
+                  </button>
+                }
+              }
+            </div>
+          }
+        </section>
       }
-      @if (latestAchievement(); as achievement) {
-        <span class="vs-avatar__achievement" [title]="achievement.name">
-          {{ achievementLabel(achievement) }}
-        </span>
-      }
     </div>
-  </a>
+
+    <a class="vs-topbar__user" routerLink="/settings" title="Ajustes">
+      <div style="text-align: right">
+        <div style="font-weight: 600; font-size: 13px">{{ displayUser().name }}</div>
+        <div class="vs-mono" style="font-size: 11px; color: var(--vs-text-muted)">{{ displayUser().xp }} XP</div>
+      </div>
+      <div class="vs-avatar">
+        @if (displayUser().avatarUrl) {
+          <img [src]="displayUser().avatarUrl" alt="" />
+        } @else {
+          {{ initials() }}
+        }
+        @if (latestAchievement(); as achievement) {
+          <span class="vs-avatar__achievement" [title]="achievement.name">
+            {{ achievementLabel(achievement) }}
+          </span>
+        }
+      </div>
+    </a>
+  </div>
 
 </div>

--- a/frontend/src/app/shared/components/layout/topbar/topbar.spec.ts
+++ b/frontend/src/app/shared/components/layout/topbar/topbar.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { signal } from '@angular/core';
+import { type Signal, type WritableSignal, computed, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { TopbarComponent } from './topbar';
@@ -9,9 +9,20 @@ import { AchievementService } from '../../../../core/services/achievement.servic
 import { UserService } from '../../../../core/services/user.service';
 import { StatsService } from '../../../../core/services/stats.service';
 import { PlayerStats } from '../../../../core/models/game.models';
+import { NotificationItem } from '../../../../core/models/notification.models';
+import { NotificationCenterService } from '../../../../core/services/notification-center.service';
 
 describe('TopbarComponent', () => {
   let fixture: ComponentFixture<TopbarComponent>;
+  let notificationItems: WritableSignal<NotificationItem[]>;
+  let notificationService: {
+    items: Signal<NotificationItem[]>;
+    unreadCount: Signal<number>;
+    start: ReturnType<typeof vi.fn>;
+    markRead: ReturnType<typeof vi.fn>;
+    markAllRead: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
+  };
 
   const authUser = signal({
     id: 'user-1',
@@ -33,6 +44,21 @@ describe('TopbarComponent', () => {
   ];
 
   beforeEach(async () => {
+    notificationItems = signal<NotificationItem[]>([]);
+    notificationService = {
+      items: notificationItems,
+      unreadCount: computed(() => notificationItems().filter((item) => !item.read).length),
+      start: vi.fn(),
+      markRead: vi.fn((id: string) => {
+        notificationItems.update((items) =>
+          items.map((item) => (item.id === id ? { ...item, read: true } : item)),
+        );
+      }),
+      markAllRead: vi.fn(() => {
+        notificationItems.update((items) => items.map((item) => ({ ...item, read: true })));
+      }),
+      clear: vi.fn(() => notificationItems.set([])),
+    };
 
     await TestBed.configureTestingModule({
       imports: [TopbarComponent],
@@ -83,6 +109,7 @@ describe('TopbarComponent', () => {
             ]),
           },
         },
+        { provide: NotificationCenterService, useValue: notificationService },
       ],
     }).compileComponents();
 
@@ -118,5 +145,33 @@ describe('TopbarComponent', () => {
     expect(text).toContain('999 XP');
     expect(img?.getAttribute('src')).toBe('https://avatar.test/a.svg');
 
+  });
+
+  it('should render notification center and mark selected notification as read', () => {
+    notificationItems.set([
+      {
+        id: 'n1',
+        type: 'MATCH_FOUND',
+        title: 'Rival encontrado',
+        message: 'player2 te espera en Duelo binario.',
+        createdAt: new Date().toISOString(),
+        read: false,
+        tone: 'info',
+        sourceId: 'match-found:match-1',
+      },
+    ]);
+    fixture.detectChanges();
+
+    const trigger = fixture.nativeElement.querySelector('.vs-notification-center__trigger') as HTMLButtonElement;
+    expect(fixture.nativeElement.querySelector('.vs-notification-center__badge')?.textContent).toContain('1');
+
+    trigger.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Rival encontrado');
+    const item = fixture.nativeElement.querySelector('.vs-notification-item') as HTMLElement;
+    item.click();
+
+    expect(notificationService.markRead).toHaveBeenCalledWith('n1');
   });
 });

--- a/frontend/src/app/shared/components/layout/topbar/topbar.ts
+++ b/frontend/src/app/shared/components/layout/topbar/topbar.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, computed, inject, input, signal } from '@angular/core';
+import { Component, ElementRef, HostListener, OnInit, computed, inject, input, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '../../../../core/services/auth.service';
 import { AchievementService } from '../../../../core/services/achievement.service';
@@ -6,6 +6,8 @@ import { StatsService } from '../../../../core/services/stats.service';
 import { UserService } from '../../../../core/services/user.service';
 import { Achievement } from '../../../../core/models/achievement.models';
 import { PlayerStats } from '../../../../core/models/game.models';
+import type { NotificationItem } from '../../../../core/models/notification.models';
+import { NotificationCenterService } from '../../../../core/services/notification-center.service';
 
 
 export type NavKey = 'home' | 'play' | 'ranking' | 'profile' | 'settings' | 'admin' | 'users' | 'spiders' | 'reports';
@@ -22,6 +24,8 @@ export class TopbarComponent implements OnInit {
   private readonly users = inject(UserService);
   private readonly statsApi = inject(StatsService);
   private readonly achievementsApi = inject(AchievementService);
+  private readonly notifications = inject(NotificationCenterService);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
 
   active = input<NavKey>('home');
   role = input<'player' | 'admin'>('player');
@@ -29,6 +33,13 @@ export class TopbarComponent implements OnInit {
 
   private readonly stats = signal<PlayerStats[]>([]);
   private readonly achievements = signal<Achievement[]>([]);
+  readonly notificationItems = this.notifications.items;
+  readonly unreadCount = this.notifications.unreadCount;
+  readonly notificationsOpen = signal(false);
+  readonly unreadLabel = computed(() => {
+    const count = this.unreadCount();
+    return count > 9 ? '9+' : String(count);
+  });
 
 
   items = computed<[NavKey, string][]>(() =>
@@ -77,6 +88,7 @@ export class TopbarComponent implements OnInit {
 
   ngOnInit(): void {
     if (!this.auth.isAuthenticated()) return;
+    this.notifications.start();
     this.users.me().subscribe({
       next: (u) => this.auth.updateCachedUser({ username: u.username, avatarUrl: u.avatarUrl, role: u.role }),
       error: () => {},
@@ -112,6 +124,58 @@ export class TopbarComponent implements OnInit {
       collector: 'C',
     };
     return labels[achievement.iconKey] ?? 'OK';
+  }
+
+  toggleNotifications(event: MouseEvent): void {
+    event.stopPropagation();
+    this.notificationsOpen.update((open) => !open);
+  }
+
+  closeNotifications(): void {
+    this.notificationsOpen.set(false);
+  }
+
+  markAllNotificationsRead(event: MouseEvent): void {
+    event.stopPropagation();
+    this.notifications.markAllRead();
+  }
+
+  clearNotifications(event: MouseEvent): void {
+    event.stopPropagation();
+    this.notifications.clear();
+  }
+
+  selectNotification(notification: NotificationItem): void {
+    this.notifications.markRead(notification.id);
+    this.closeNotifications();
+  }
+
+  notificationIcon(notification: NotificationItem): string {
+    if (notification.type === 'ACHIEVEMENT_UNLOCKED') return 'OK';
+    if (notification.type === 'MATCH_FOUND') return 'VS';
+    if (notification.tone === 'danger') return '!';
+    return 'i';
+  }
+
+  notificationTime(notification: NotificationItem): string {
+    const time = new Date(notification.createdAt).getTime();
+    if (!Number.isFinite(time)) return '';
+
+    const diff = Math.max(0, Date.now() - time);
+    const minute = 60 * 1000;
+    const hour = 60 * minute;
+    if (diff < minute) return 'ahora';
+    if (diff < hour) return `${Math.floor(diff / minute)} min`;
+    if (diff < 24 * hour) return `${Math.floor(diff / hour)} h`;
+    return new Date(time).toLocaleDateString('es-ES', { day: '2-digit', month: 'short' });
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.notificationsOpen()) return;
+    if (!this.elementRef.nativeElement.contains(event.target as Node)) {
+      this.closeNotifications();
+    }
   }
 
   private calculateXp(stats: PlayerStats[]): number {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -294,6 +294,237 @@ html, body {
 
     &:hover .vs-avatar { border-color: var(--vs-border-focus); }
   }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+}
+
+.vs-icon-btn {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--vs-border);
+  border-radius: var(--vs-radius-sm);
+  background: transparent;
+  color: var(--vs-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  position: relative;
+  transition: border-color var(--vs-transition), color var(--vs-transition), background var(--vs-transition);
+
+  &:hover {
+    border-color: var(--vs-border-focus);
+    color: var(--vs-text-primary);
+    background: rgba(255,255,255,0.03);
+  }
+
+  svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  &--sm {
+    width: 30px;
+    height: 30px;
+
+    svg {
+      width: 15px;
+      height: 15px;
+    }
+  }
+}
+
+.vs-notification-center {
+  position: relative;
+  z-index: 80;
+}
+
+.vs-notification-center__trigger {
+  color: var(--vs-text-primary);
+}
+
+.vs-notification-center__badge {
+  position: absolute;
+  right: -6px;
+  top: -6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--vs-accent-red);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--vs-bg-base);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.vs-notification-center__panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(380px, calc(100vw - 32px));
+  max-height: 440px;
+  overflow: hidden;
+  background: var(--vs-bg-elevated);
+  border: 1px solid var(--vs-border-strong);
+  border-radius: var(--vs-radius-md);
+  box-shadow: 0 18px 60px rgba(0,0,0,0.6);
+  animation: vs-fade-in 160ms ease forwards;
+}
+
+.vs-notification-center__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--vs-border);
+
+  .vs-section-title {
+    margin-bottom: 4px;
+  }
+}
+
+.vs-notification-center__count {
+  color: var(--vs-text-secondary);
+  font-size: 12px;
+}
+
+.vs-notification-center__tools {
+  display: flex;
+  gap: 8px;
+}
+
+.vs-notification-center__empty {
+  padding: 28px 16px;
+  color: var(--vs-text-muted);
+  text-align: center;
+  font-size: 13px;
+}
+
+.vs-notification-center__list {
+  max-height: 342px;
+  overflow: auto;
+}
+
+.vs-notification-item {
+  appearance: none;
+  border: none;
+  border-top: 1px solid var(--vs-border);
+  background: transparent;
+  color: var(--vs-text-primary);
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 12px;
+  width: 100%;
+  padding: 14px 16px;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+
+  &:first-child {
+    border-top: none;
+  }
+
+  &:hover {
+    background: rgba(255,255,255,0.035);
+  }
+
+  &.is-unread {
+    background: rgba(67,97,238,0.08);
+  }
+}
+
+.vs-notification-item__icon {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--vs-radius-sm);
+  background: rgba(67,97,238,0.13);
+  color: var(--vs-accent-blue);
+  display: inline-grid;
+  place-items: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.vs-notification-item.tone-success .vs-notification-item__icon {
+  background: rgba(46,196,182,0.13);
+  color: var(--vs-accent-green);
+}
+
+.vs-notification-item.tone-warning .vs-notification-item__icon {
+  background: rgba(244,197,66,0.13);
+  color: var(--vs-accent-gold);
+}
+
+.vs-notification-item.tone-danger .vs-notification-item__icon {
+  background: rgba(230,57,70,0.13);
+  color: var(--vs-accent-red);
+}
+
+.vs-notification-item__body {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.vs-notification-item__title {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.vs-notification-item__message {
+  color: var(--vs-text-secondary);
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.vs-notification-item__time {
+  color: var(--vs-text-muted);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+}
+
+@media (max-width: 760px) {
+  .vs-topbar {
+    padding: 12px 16px;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .vs-topbar__nav {
+    order: 3;
+    width: 100%;
+    gap: 16px;
+    justify-content: center;
+    overflow-x: auto;
+    padding-top: 4px;
+  }
+
+  .vs-topbar__user > div:first-child {
+    display: none;
+  }
+
+  .vs-notification-center__panel {
+    right: -48px;
+  }
 }
 
 .vs-avatar img {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -4,6 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
+    "rootDir": "./src",
     "types": []
   },
   "include": [


### PR DESCRIPTION
Implementado el centro de notificaciones en tiempo real en el topbar. Escucha eventos STOMP de logros desbloqueados y matchmaking, muestra contador de no leídas, permite marcar/vaciar notificaciones y guarda el historial por usuario en localStorage, respetando las preferencias de /settings.

También se añadieron tests, se corrigió el aviso de rootDir en tsconfig.app.json y se documentó la funcionalidad en la arquitectura frontend, contratos técnicos y módulos relacionados.