### PR TITLE
fix: Websockets en produccion

### DIFF
--- a/backend/src/main/java/com/versus/api/websocket/WebSocketConfig.java
+++ b/backend/src/main/java/com/versus/api/websocket/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.versus.api.websocket;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -15,12 +16,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtChannelInterceptor jwtChannelInterceptor;
 
+    @Value("${versus.frontend.base-url:http://localhost:4200}")
+    private String frontendBaseUrl;
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        String[] origins = { frontendBaseUrl, "https://www.vrsus.online" };
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("http://localhost:4200");
+                .setAllowedOriginPatterns(origins);
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("http://localhost:4200")
+                .setAllowedOriginPatterns(origins)
                 .withSockJS();
     }
 


### PR DESCRIPTION
Ahora el endpoint STOMP lee el origen permitido de versus.frontend.base-url (en prod = https://vrsus.online vía el
  env var FRONTEND_BASE_URL) e incluye también https://www.vrsus.online. En dev sigue usando http://localhost:4200 por el default.