### PR TITLE
fix: arregla 404 en modos single-player y cuelgue de multijugador cuando no hay preguntas

### DIFF
--- a/backend/src/main/java/com/versus/api/config/DevSeedConfig.java
+++ b/backend/src/main/java/com/versus/api/config/DevSeedConfig.java
@@ -1,10 +1,5 @@
 package com.versus.api.config;
 
-import com.versus.api.questions.QuestionStatus;
-import com.versus.api.questions.QuestionType;
-import com.versus.api.questions.domain.Question;
-import com.versus.api.questions.domain.QuestionOption;
-import com.versus.api.questions.repo.QuestionRepository;
 import com.versus.api.users.Role;
 import com.versus.api.users.domain.User;
 import com.versus.api.users.repo.UserRepository;
@@ -16,9 +11,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.math.BigDecimal;
-import java.time.Instant;
-
 @Configuration
 @Profile("dev")
 @RequiredArgsConstructor
@@ -26,16 +18,11 @@ import java.time.Instant;
 public class DevSeedConfig {
 
     private final UserRepository users;
-    private final QuestionRepository questions;
     private final PasswordEncoder passwordEncoder;
 
     @Bean
     CommandLineRunner seedDevData() {
-        return args -> {
-            seedUsers();
-            seedBinaryQuestions();
-            seedNumericQuestions();
-        };
+        return args -> seedUsers();
     }
 
     private void seedUsers() {
@@ -55,80 +42,5 @@ public class DevSeedConfig {
                 .role(role)
                 .isActive(true)
                 .build());
-    }
-
-    private void seedBinaryQuestions() {
-        if (questions.countByStatusAndType(QuestionStatus.ACTIVE, QuestionType.BINARY) > 0) {
-            return;
-        }
-        binary("football", "Who has won more Ballon d'Or awards?", "Lionel Messi", "Cristiano Ronaldo");
-        binary("football", "Which club has more UEFA Champions League titles?", "Real Madrid", "Manchester United");
-        binary("football", "Who scored more official goals for Brazil?", "Pele", "Ronaldo Nazario");
-        binary("football", "Which country has more FIFA World Cup titles?", "Brazil", "Argentina");
-        binary("football", "Who has more Premier League titles?", "Manchester United", "Liverpool");
-
-        binary("geography", "Which country has the larger population?", "India", "Canada");
-        binary("geography", "Which river is longer?", "Nile", "Thames");
-        binary("geography", "Which mountain is higher?", "Mount Everest", "Mont Blanc");
-        binary("geography", "Which country is larger by area?", "Russia", "Spain");
-        binary("geography", "Which city is farther north?", "Oslo", "Rome");
-
-        binary("cinema", "Which film won more Oscars?", "The Lord of the Rings: The Return of the King", "Titanic");
-        binary("cinema", "Who directed Jurassic Park?", "Steven Spielberg", "James Cameron");
-        binary("cinema", "Which franchise released its first film earlier?", "Star Wars", "Harry Potter");
-        binary("cinema", "Which actor played Iron Man in the MCU?", "Robert Downey Jr.", "Chris Evans");
-        binary("cinema", "Which movie has the longer runtime?", "The Godfather Part II", "Toy Story");
-    }
-
-    private void seedNumericQuestions() {
-        if (questions.countByStatusAndType(QuestionStatus.ACTIVE, QuestionType.NUMERIC) > 0) {
-            return;
-        }
-        numeric("football", "How many players start on the pitch for one football team?", "players", "11", "0");
-        numeric("football", "How many minutes are in standard football regulation time?", "minutes", "90", "0");
-        numeric("football", "How many FIFA World Cup titles does Brazil have?", "titles", "5", "0");
-        numeric("football", "How many teams played in the 2022 FIFA World Cup?", "teams", "32", "0");
-
-        numeric("geography", "What is the approximate height of Mount Everest?", "meters", "8849", "2");
-        numeric("geography", "How many countries are in the European Union?", "countries", "27", "0");
-        numeric("geography", "What is the approximate population of Spain?", "millions", "48", "5");
-
-        numeric("cinema", "How many Oscars did Titanic win?", "Oscars", "11", "0");
-        numeric("cinema", "What year was the first Star Wars film released?", "year", "1977", "0");
-        numeric("cinema", "What is the approximate runtime of The Godfather?", "minutes", "175", "5");
-    }
-
-    private void binary(String category, String text, String correct, String incorrect) {
-        Question question = baseQuestion(category, text, QuestionType.BINARY);
-        question.getOptions().add(QuestionOption.builder()
-                .question(question)
-                .text(correct)
-                .isCorrect(true)
-                .build());
-        question.getOptions().add(QuestionOption.builder()
-                .question(question)
-                .text(incorrect)
-                .isCorrect(false)
-                .build());
-        questions.save(question);
-    }
-
-    private void numeric(String category, String text, String unit, String correctValue, String tolerancePercent) {
-        Question question = baseQuestion(category, text, QuestionType.NUMERIC);
-        question.setUnit(unit);
-        question.setCorrectValue(new BigDecimal(correctValue));
-        question.setTolerancePercent(new BigDecimal(tolerancePercent));
-        questions.save(question);
-    }
-
-    private Question baseQuestion(String category, String text, QuestionType type) {
-        return Question.builder()
-                .text(text)
-                .type(type)
-                .category(category)
-                .sourceUrl("seed://dev")
-                .scrapedAt(Instant.now())
-                .status(QuestionStatus.ACTIVE)
-                .build();
     }
 }

--- a/backend/src/main/java/com/versus/api/config/QuestionSeedConfig.java
+++ b/backend/src/main/java/com/versus/api/config/QuestionSeedConfig.java
@@ -1,0 +1,108 @@
+package com.versus.api.config;
+
+import com.versus.api.questions.QuestionStatus;
+import com.versus.api.questions.QuestionType;
+import com.versus.api.questions.domain.Question;
+import com.versus.api.questions.domain.QuestionOption;
+import com.versus.api.questions.repo.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class QuestionSeedConfig {
+
+    private final QuestionRepository questions;
+
+    @Bean
+    CommandLineRunner seedQuestionsIfEmpty() {
+        return args -> {
+            seedBinaryIfEmpty();
+            seedNumericIfEmpty();
+        };
+    }
+
+    private void seedBinaryIfEmpty() {
+        if (questions.countByStatusAndType(QuestionStatus.ACTIVE, QuestionType.BINARY) > 0) {
+            return;
+        }
+        log.info("No ACTIVE BINARY questions found — seeding default catalogue");
+        binary("football", "Who has won more Ballon d'Or awards?", "Lionel Messi", "Cristiano Ronaldo");
+        binary("football", "Which club has more UEFA Champions League titles?", "Real Madrid", "Manchester United");
+        binary("football", "Who scored more official goals for Brazil?", "Pele", "Ronaldo Nazario");
+        binary("football", "Which country has more FIFA World Cup titles?", "Brazil", "Argentina");
+        binary("football", "Who has more Premier League titles?", "Manchester United", "Liverpool");
+
+        binary("geography", "Which country has the larger population?", "India", "Canada");
+        binary("geography", "Which river is longer?", "Nile", "Thames");
+        binary("geography", "Which mountain is higher?", "Mount Everest", "Mont Blanc");
+        binary("geography", "Which country is larger by area?", "Russia", "Spain");
+        binary("geography", "Which city is farther north?", "Oslo", "Rome");
+
+        binary("cinema", "Which film won more Oscars?", "The Lord of the Rings: The Return of the King", "Titanic");
+        binary("cinema", "Who directed Jurassic Park?", "Steven Spielberg", "James Cameron");
+        binary("cinema", "Which franchise released its first film earlier?", "Star Wars", "Harry Potter");
+        binary("cinema", "Which actor played Iron Man in the MCU?", "Robert Downey Jr.", "Chris Evans");
+        binary("cinema", "Which movie has the longer runtime?", "The Godfather Part II", "Toy Story");
+    }
+
+    private void seedNumericIfEmpty() {
+        if (questions.countByStatusAndType(QuestionStatus.ACTIVE, QuestionType.NUMERIC) > 0) {
+            return;
+        }
+        log.info("No ACTIVE NUMERIC questions found — seeding default catalogue");
+        numeric("football", "How many players start on the pitch for one football team?", "players", "11", "0");
+        numeric("football", "How many minutes are in standard football regulation time?", "minutes", "90", "0");
+        numeric("football", "How many FIFA World Cup titles does Brazil have?", "titles", "5", "0");
+        numeric("football", "How many teams played in the 2022 FIFA World Cup?", "teams", "32", "0");
+
+        numeric("geography", "What is the approximate height of Mount Everest?", "meters", "8849", "2");
+        numeric("geography", "How many countries are in the European Union?", "countries", "27", "0");
+        numeric("geography", "What is the approximate population of Spain?", "millions", "48", "5");
+
+        numeric("cinema", "How many Oscars did Titanic win?", "Oscars", "11", "0");
+        numeric("cinema", "What year was the first Star Wars film released?", "year", "1977", "0");
+        numeric("cinema", "What is the approximate runtime of The Godfather?", "minutes", "175", "5");
+    }
+
+    private void binary(String category, String text, String correct, String incorrect) {
+        Question question = baseQuestion(category, text, QuestionType.BINARY);
+        question.getOptions().add(QuestionOption.builder()
+                .question(question)
+                .text(correct)
+                .isCorrect(true)
+                .build());
+        question.getOptions().add(QuestionOption.builder()
+                .question(question)
+                .text(incorrect)
+                .isCorrect(false)
+                .build());
+        questions.save(question);
+    }
+
+    private void numeric(String category, String text, String unit, String correctValue, String tolerancePercent) {
+        Question question = baseQuestion(category, text, QuestionType.NUMERIC);
+        question.setUnit(unit);
+        question.setCorrectValue(new BigDecimal(correctValue));
+        question.setTolerancePercent(new BigDecimal(tolerancePercent));
+        questions.save(question);
+    }
+
+    private Question baseQuestion(String category, String text, QuestionType type) {
+        return Question.builder()
+                .text(text)
+                .type(type)
+                .category(category)
+                .sourceUrl("seed://default")
+                .scrapedAt(Instant.now())
+                .status(QuestionStatus.ACTIVE)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/versus/api/duel/DuelOrchestrator.java
+++ b/backend/src/main/java/com/versus/api/duel/DuelOrchestrator.java
@@ -2,6 +2,7 @@ package com.versus.api.duel;
 
 import com.versus.api.achievements.dto.AchievementResponse;
 import com.versus.api.common.exception.ApiException;
+import com.versus.api.common.exception.ErrorCode;
 import com.versus.api.duel.dto.AnswerMessage;
 import com.versus.api.duel.dto.AnswerResultPayload;
 import com.versus.api.duel.dto.EffectAppliedPayload;
@@ -140,7 +141,18 @@ public class DuelOrchestrator {
                 return;
             }
 
-            Question question = questions.findRandomActiveQuestion(engine.questionType(), null);
+            Question question;
+            try {
+                question = questions.findRandomActiveQuestion(engine.questionType(), null);
+            } catch (ApiException ex) {
+                if (ex.getCode() == ErrorCode.NOT_FOUND) {
+                    log.warn("Match {} ending early: no active question of type {} available",
+                            matchId, engine.questionType());
+                    endMatchNoQuestion(duel);
+                    return;
+                }
+                throw ex;
+            }
             Instant now = Instant.now();
 
             DuelRoundState round = new DuelRoundState(n, question.getId(), now, computeDeadline(duel, now));
@@ -377,6 +389,10 @@ public class DuelOrchestrator {
 
     private void endMatchMaxRounds(DuelMatchState duel) {
         finalize(duel, MatchEndPayload.REASON_MAX_ROUNDS_TIE);
+    }
+
+    private void endMatchNoQuestion(DuelMatchState duel) {
+        finalize(duel, MatchEndPayload.REASON_NO_QUESTION);
     }
 
     private void endMatchDisconnect(DuelMatchState duel, UUID disconnectedUserId) {

--- a/backend/src/main/java/com/versus/api/duel/dto/MatchEndPayload.java
+++ b/backend/src/main/java/com/versus/api/duel/dto/MatchEndPayload.java
@@ -11,4 +11,5 @@ public record MatchEndPayload(
     public static final String REASON_NORMAL = "NORMAL";
     public static final String REASON_DISCONNECT = "DISCONNECT";
     public static final String REASON_MAX_ROUNDS_TIE = "MAX_ROUNDS_TIE";
+    public static final String REASON_NO_QUESTION = "NO_QUESTION";
 }

--- a/frontend/src/app/core/models/duel.models.ts
+++ b/frontend/src/app/core/models/duel.models.ts
@@ -62,7 +62,7 @@ export interface FinalStatsPayload {
 
 export interface MatchEndPayload {
   winnerUserId: string | null;
-  reason: 'NORMAL' | 'DISCONNECT' | 'MAX_ROUNDS_TIE';
+  reason: 'NORMAL' | 'DISCONNECT' | 'MAX_ROUNDS_TIE' | 'NO_QUESTION';
   stats: FinalStatsPayload[];
 }
 

--- a/frontend/src/app/features/player/pages/result/result.ts
+++ b/frontend/src/app/features/player/pages/result/result.ts
@@ -25,7 +25,7 @@ export interface ResultState {
   livesRemaining?: number;
   avgDeviation?: number | null;
   opponent?: OpponentRecap;
-  reason?: 'NORMAL' | 'DISCONNECT' | 'MAX_ROUNDS_TIE';
+  reason?: 'NORMAL' | 'DISCONNECT' | 'MAX_ROUNDS_TIE' | 'NO_QUESTION';
   sabotagesUsed?: number;
 }
 
@@ -71,6 +71,7 @@ export class Result {
     const r = this.state()?.reason;
     if (r === 'DISCONNECT') return 'Tu rival se desconectó.';
     if (r === 'MAX_ROUNDS_TIE') return 'Se alcanzó el límite de rondas.';
+    if (r === 'NO_QUESTION') return 'La partida no pudo continuar: no hay preguntas disponibles para este modo.';
     return null;
   });
 

--- a/frontend/src/app/features/precision/pages/precision/precision.ts
+++ b/frontend/src/app/features/precision/pages/precision/precision.ts
@@ -96,9 +96,16 @@ export class Precision implements OnInit, OnDestroy {
         this.phase.set('idle');
         audioService.playBgm('bgm_game');
       },
-      error: () => {
+      error: (err) => {
         this.phase.set('idle');
-        this.errorMessage.set('No se pudo iniciar la partida.');
+        const serverMsg = err?.error?.message as string | undefined;
+        const noQuestions =
+          err?.status === 404 && /no active question/i.test(serverMsg ?? '');
+        this.errorMessage.set(
+          noQuestions
+            ? 'Aún no hay preguntas disponibles para este modo. Inténtalo más tarde.'
+            : serverMsg || 'No se pudo iniciar la partida.',
+        );
       },
     });
   }

--- a/frontend/src/app/features/survival/pages/survival/survival.ts
+++ b/frontend/src/app/features/survival/pages/survival/survival.ts
@@ -135,9 +135,16 @@ export class Survival implements OnInit, OnDestroy {
         this.phase.set('idle');
         audioService.playBgm('bgm_game');
       },
-      error: () => {
+      error: (err) => {
         this.phase.set('idle');
-        this.errorMessage.set('No se pudo iniciar la partida.');
+        const serverMsg = err?.error?.message as string | undefined;
+        const noQuestions =
+          err?.status === 404 && /no active question/i.test(serverMsg ?? '');
+        this.errorMessage.set(
+          noQuestions
+            ? 'Aún no hay preguntas disponibles para este modo. Inténtalo más tarde.'
+            : serverMsg || 'No se pudo iniciar la partida.',
+        );
       },
     });
   }


### PR DESCRIPTION
Issue #160

 ## Resumen

Los modos **Supervivencia** y **Precisión** devolvían `404 /api/game/{mode}/start` ("No se pudo iniciar partida") y los modos multijugador (**Duelo Binario**, **Duelo de Precisión** y **Sabotaje**) entraban a la sala pero se quedaban en pantalla de "conectando" sin recibir nunca la primera pregunta. El error de consola *"A listener indicated an asynchronous response..."* era ruido de una extensión del navegador y no estaba relacionado.

---

## Causa raíz

`QuestionService.findRandomActiveQuestion` lanza `ApiException.notFound("No active question found")` cuando no hay preguntas `ACTIVE` del tipo pedido. En producción la tabla `questions` estaba vacía (el seed dev sólo corre con `@Profile("dev")` + `versus.seed.enabled=true`):

* **Single-player**: La excepción se propaga al `@RestController`, el `GlobalExceptionHandler` la mapea a HTTP 404 → el frontend muestra "No se pudo iniciar partida".
* **Multijugador**: La excepción se lanza dentro de `DuelOrchestrator.startNextRound`, pero `safeStartNextRound` la traga con un `log.error`. La partida queda viva en memoria sin enviar nunca el evento `QUESTION`, así que el cliente entra al modo y no ve nada.

---

## Cambios

### **Backend**
* `config/QuestionSeedConfig.java` *(nuevo)*: `CommandLineRunner` profile-agnostic que siembra preguntas BINARY/NUMERIC sólo si `countByStatusAndType(ACTIVE, type) == 0`. Es idempotente y no toca la tabla si ya hay datos.
* `config/DevSeedConfig.java`: Queda restringido a sembrar usuarios dev (player/moderator/admin). El catálogo de preguntas se movió al runner nuevo.
* `duel/DuelOrchestrator.java`: En `startNextRound`, si `findRandomActiveQuestion` lanza `NOT_FOUND`, se cierra la partida con `endMatchNoQuestion(duel)` que emite `MATCH_END` con `reason = NO_QUESTION` en lugar de tragar la excepción.
* `duel/dto/MatchEndPayload.java`: Añade la constante `REASON_NO_QUESTION`.

### **Frontend**
* `core/models/duel.models.ts` + `features/player/pages/result/result.ts`: Añaden el motivo `NO_QUESTION` y un mensaje legible ("La partida no pudo continuar: no hay preguntas disponibles para este modo.").
* `features/survival/pages/survival/survival.ts` + `features/precision/pages/precision/precision.ts`: Si el `start` falla con 404 + "No active question", muestran "Aún no hay preguntas disponibles para este modo. Inténtalo más tarde."; en otros errores propagan el `message` del servidor.

---

## Impacto en el futuro módulo de preguntas (scraper)

Cuando el scraper Scrapy (módulo de preguntas) empiece a poblar la tabla `questions`, hay que tener en cuenta:

1.  **El seed sólo dispara con la tabla vacía por tipo.** En cuanto el scraper haya insertado al menos una pregunta `ACTIVE` de un tipo concreto, `QuestionSeedConfig` deja de tocar ese tipo. No mezcla datos seeded con datos reales en operación normal.
2.  **Cuidado con el flujo de moderación.** El seed cuenta `status = ACTIVE`. Si el scraper guarda las preguntas como `PENDING_REVIEW` y necesitan aprobación manual antes de pasar a `ACTIVE`, entre el primer scrape y la primera aprobación seguirá habiendo `count(ACTIVE) == 0` y el seed se reactivaría en el siguiente arranque. **Opciones:**
    * Marcar las preguntas seed con un `sourceUrl = "seed://default"` (ya lo hace) y borrarlas vía una tarea de housekeeping cuando haya suficientes preguntas reales aprobadas.
    * Sustituir la condición del seed por un flag de configuración (`versus.seed.questions.enabled`) y desactivarlo en cuanto el scraper esté operativo.
    * Cambiar la comprobación a `countByType > 0` (independiente de status) para que un catálogo en revisión también lo desactive.
3.  **Tipos parciales.** El seed siembra BINARY y NUMERIC de forma independiente. Si el scraper sólo produce uno de los dos tipos, el otro seguirá poblándose con las preguntas seed. Aceptable a corto plazo pero conviene revisarlo cuando se cierre la pipeline.
4.  **`DuelOrchestrator` ahora finaliza partidas con `NO_QUESTION` en vez de colgarlas.** Si el scraper introduce categorías con muy pocas preguntas activas y se filtra por categoría en futuras versiones del matchmaking, este caborde dejará de ser invisible: las partidas terminarán limpiamente y el cliente verá el motivo. Conviene tenerlo en cuenta al añadir filtros por categoría/dificultad para no crear "muros" sin querer.
5.  **Schema sin cambios.** No se ha tocado la entidad `Question` ni el repositorio, así que la integración del scraper no necesita migraciones por este PR.

---

## Test plan

- [ ] **Backend:** `mvn clean compile` y `mvn test`.
- [ ] **Frontend:** `tsc --noEmit` y `ng test`.
- [ ] Arrancar con BD vacía → comprobar que en logs aparece *"No ACTIVE BINARY/NUMERIC questions found — seeding default catalogue"* y los endpoints `/api/game/survival/start` y `/api/game/precision/start` devuelven 200.
- [ ] Arrancar con BD ya poblada → comprobar que el seed no inserta nada (el `count` corta antes del save).
- [ ] Borrar manualmente todas las preguntas y entrar a un duelo binario → la partida debe finalizar con `MATCH_END / reason: NO_QUESTION` y la pantalla de resultado debe mostrar el mensaje correspondiente, en vez de quedarse colgada.
- [ ] Verificar que el seed dev de usuarios (player/moderator/admin) sigue funcionando en perfil `dev`.