### PR TITLE
Add CI job for production build verification and improve test feedback

### DIFF
--- a/.github/scripts/jacoco-coverage.sh
+++ b/.github/scripts/jacoco-coverage.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Imprime el porcentaje de cobertura de LÍNEAS a partir de un jacoco.xml.
+# El informe contiene un <counter type="LINE" missed=".." covered=".."/> a
+# nivel de <report> (el último del fichero). Salida: número con 1 decimal.
+# Si el fichero no existe o no hay datos, imprime "0.0".
+
+set -uo pipefail
+XML="${1:-}"
+
+if [ ! -f "$XML" ]; then
+  echo "0.0"; exit 0
+fi
+
+# Última línea LINE counter = agregado del report.
+read -r MISSED COVERED < <(
+  grep -oP '<counter type="LINE" missed="\K[0-9]+" covered="[0-9]+"' "$XML" \
+    | tail -1 \
+    | sed -E 's/" covered="/ /; s/"$//'
+)
+
+MISSED="${MISSED:-0}"; COVERED="${COVERED:-0}"
+TOTAL=$(( MISSED + COVERED ))
+if [ "$TOTAL" -eq 0 ]; then echo "0.0"; exit 0; fi
+
+awk -v c="$COVERED" -v t="$TOTAL" 'BEGIN { printf "%.1f", (c*100)/t }'

--- a/.github/scripts/junit-counts.sh
+++ b/.github/scripts/junit-counts.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Suma los atributos de los <testsuite>/<testsuite> de uno o más ficheros JUnit
+# XML (Surefire, Failsafe o vitest/jest-junit) y exporta:
+#   TOTAL PASSED FAILURES ERRORS SKIPPED
+#
+# Uso (con `source` para heredar las variables en el shell llamante):
+#   source junit-counts.sh path/to/TEST-*.xml
+#
+# Si no hay ficheros (la build falló antes de generar reportes), todo queda a 0.
+
+set -uo pipefail
+
+_sum_attr() {
+  # $1 = nombre de atributo; resto = ficheros. Suma solo los <testsuite ...>
+  # de primer nivel para no duplicar con <testcase>.
+  local attr="$1"; shift
+  grep -rh "<testsuite " "$@" 2>/dev/null \
+    | grep -oP "${attr}=\"\K[0-9]+" \
+    | awk '{s+=$1} END {print s+0}'
+}
+
+TOTAL=$(_sum_attr tests "$@")
+FAILURES=$(_sum_attr failures "$@")
+ERRORS=$(_sum_attr errors "$@")
+SKIPPED=$(_sum_attr skipped "$@")
+PASSED=$(( TOTAL - FAILURES - ERRORS - SKIPPED ))
+
+export TOTAL FAILURES ERRORS SKIPPED PASSED

--- a/.github/scripts/lcov-coverage.sh
+++ b/.github/scripts/lcov-coverage.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Imprime el porcentaje de cobertura de LÍNEAS a partir de un lcov.info.
+# Suma LF (líneas encontradas) y LH (líneas cubiertas) de todos los ficheros.
+# Salida: número con 1 decimal. Si no hay datos, imprime "0.0".
+
+set -uo pipefail
+LCOV="${1:-}"
+
+if [ ! -f "$LCOV" ]; then
+  echo "0.0"; exit 0
+fi
+
+LF=$(grep -oP '^LF:\K[0-9]+' "$LCOV" | awk '{s+=$1} END {print s+0}')
+LH=$(grep -oP '^LH:\K[0-9]+' "$LCOV" | awk '{s+=$1} END {print s+0}')
+
+if [ "${LF:-0}" -eq 0 ]; then echo "0.0"; exit 0; fi
+
+awk -v h="$LH" -v f="$LF" 'BEGIN { printf "%.1f", (h*100)/f }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,44 @@ jobs:
           path: backend/target/failsafe-reports/
           retention-days: 7
 
+  # ──────────────────────────────────────────────
+  # Job 3: Verificar la build de producción
+  # Garantiza que las imágenes de producción compilan ANTES de poder
+  # mergear a main, evitando builds rotas en main que bloquean el deploy.
+  # No se publican imágenes aquí — solo se valida que la build pasa.
+  # Reutiliza los mismos scopes de caché gha que el workflow de deploy,
+  # de forma que el build posterior al merge arranca con caché caliente.
+  # ──────────────────────────────────────────────
+  build-verification:
+    name: Verificar build de producción
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend (production target)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          target: production
+          push: false
+          load: false
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max
+
+      - name: Build frontend (production target)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          target: production
+          push: false
+          load: false
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI — Tests
+name: CI
 
 on:
   pull_request_target:
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   checks: write
+  pull-requests: write   # necesario para el comentario sticky de resultados
 
 concurrency:
   group: ci-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.ref_name }}
@@ -17,17 +18,24 @@ concurrency:
 
 jobs:
   # ──────────────────────────────────────────────
-  # Job 1: Test unitarios
+  # Backend · Pruebas unitarias (Surefire)
   # ──────────────────────────────────────────────
-  test-backend:
-    name: Test unitarios
+  backend-unit:
+    name: Backend · Unit tests
     runs-on: ubuntu-latest
+    outputs:
+      total: ${{ steps.counts.outputs.total }}
+      passed: ${{ steps.counts.outputs.passed }}
+      failed: ${{ steps.counts.outputs.failed }}
+      errors: ${{ steps.counts.outputs.errors }}
+      skipped: ${{ steps.counts.outputs.skipped }}
+      coverage: ${{ steps.counts.outputs.coverage }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # For PRs (including forks): test the contributor's code, not the base branch.
+          # En PRs (incluidos forks): probar el código del contribuidor, no la base.
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Java 25
@@ -37,11 +45,29 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Run tests
+      - name: Run unit tests + coverage
         working-directory: backend
         run: |
           chmod +x mvnw
-          ./mvnw test --batch-mode -Dstyle.color=never
+          # jacoco:report genera target/site/jacoco/jacoco.xml a partir de la
+          # ejecución de Surefire (el agente se inyecta vía jacoco:prepare-agent).
+          ./mvnw test jacoco:report --batch-mode -Dstyle.color=never
+
+      - name: Compute counts & coverage
+        id: counts
+        if: always()
+        run: |
+          REPORTS=backend/target/surefire-reports
+          JACOCO=backend/target/site/jacoco/jacoco.xml
+          source .github/scripts/junit-counts.sh "$REPORTS"/TEST-*.xml
+          {
+            echo "total=$TOTAL"
+            echo "passed=$PASSED"
+            echo "failed=$FAILURES"
+            echo "errors=$ERRORS"
+            echo "skipped=$SKIPPED"
+            echo "coverage=$(.github/scripts/jacoco-coverage.sh "$JACOCO")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v4
@@ -55,40 +81,40 @@ jobs:
         uses: dorny/test-reporter@v1
         if: always()
         with:
-          name: Backend Tests
+          name: Backend · Unit tests (report)
           path: backend/target/surefire-reports/TEST-*.xml
           reporter: java-junit
           fail-on-error: 'true'
 
-      - name: Write job summary
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-unit-coverage
+          path: backend/target/site/jacoco/
+          retention-days: 7
+
+      - name: Job summary
         if: always()
         run: |
-          echo "## Backend Tests" >> $GITHUB_STEP_SUMMARY
-          if [ -d backend/target/surefire-reports ]; then
-            TOTAL=$(grep -rh 'tests="' backend/target/surefire-reports/TEST-*.xml 2>/dev/null \
-              | grep -oP 'tests="\K[0-9]+' | awk '{s+=$1} END {print s+0}')
-            FAILURES=$(grep -rh 'failures="' backend/target/surefire-reports/TEST-*.xml 2>/dev/null \
-              | grep -oP 'failures="\K[0-9]+' | awk '{s+=$1} END {print s+0}')
-            ERRORS=$(grep -rh 'errors="' backend/target/surefire-reports/TEST-*.xml 2>/dev/null \
-              | grep -oP 'errors="\K[0-9]+' | awk '{s+=$1} END {print s+0}')
-            SKIPPED=$(grep -rh 'skipped="' backend/target/surefire-reports/TEST-*.xml 2>/dev/null \
-              | grep -oP 'skipped="\K[0-9]+' | awk '{s+=$1} END {print s+0}')
-            echo "| Total | Passed | Failed | Errors | Skipped |" >> $GITHUB_STEP_SUMMARY
-            echo "|-------|--------|--------|--------|---------|" >> $GITHUB_STEP_SUMMARY
-            PASSED=$(( TOTAL - FAILURES - ERRORS - SKIPPED ))
-            echo "| $TOTAL | $PASSED | $FAILURES | $ERRORS | $SKIPPED |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "_No Surefire reports found — build may have failed before tests ran._" >> $GITHUB_STEP_SUMMARY
-          fi
-
-
+          echo "## Backend · Unit tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Total | Passed | Failed | Errors | Skipped | Coverage |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|--------|--------|---------|----------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ${{ steps.counts.outputs.total }} | ${{ steps.counts.outputs.passed }} | ${{ steps.counts.outputs.failed }} | ${{ steps.counts.outputs.errors }} | ${{ steps.counts.outputs.skipped }} | ${{ steps.counts.outputs.coverage }}% |" >> "$GITHUB_STEP_SUMMARY"
 
   # ──────────────────────────────────────────────
-  # Job 2: Tests de integración
+  # Backend · Pruebas de integración (Failsafe, en Docker)
   # ──────────────────────────────────────────────
-  test-integration:
-    name: Tests de integración
+  backend-integration:
+    name: Backend · Integration tests
     runs-on: ubuntu-latest
+    outputs:
+      total: ${{ steps.counts.outputs.total }}
+      passed: ${{ steps.counts.outputs.passed }}
+      failed: ${{ steps.counts.outputs.failed }}
+      errors: ${{ steps.counts.outputs.errors }}
+      skipped: ${{ steps.counts.outputs.skipped }}
+      coverage: ${{ steps.counts.outputs.coverage }}
 
     steps:
       - name: Checkout
@@ -97,8 +123,8 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       # Mismos contenedores que en local: db-test + backend-test bajo el perfil
-      # "test" del stack versus. Failsafe corre dentro de backend-test contra
-      # db-test:5432 (env vars SPRING_DATASOURCE_* del compose).
+      # "test". `mvnw verify` corre Surefire + Failsafe; el volumen ./backend:/app
+      # hace que reportes y cobertura aparezcan en backend/target del runner.
       - name: Run integration tests (docker compose)
         run: |
           docker compose -f docker-compose.test.yml \
@@ -117,6 +143,22 @@ jobs:
           docker compose -f docker-compose.test.yml \
             --profile test down -v || true
 
+      - name: Compute counts & coverage
+        id: counts
+        if: always()
+        run: |
+          REPORTS=backend/target/failsafe-reports
+          JACOCO=backend/target/site/jacoco/jacoco.xml
+          source .github/scripts/junit-counts.sh "$REPORTS"/TEST-*.xml
+          {
+            echo "total=$TOTAL"
+            echo "passed=$PASSED"
+            echo "failed=$FAILURES"
+            echo "errors=$ERRORS"
+            echo "skipped=$SKIPPED"
+            echo "coverage=$(.github/scripts/jacoco-coverage.sh "$JACOCO")"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Upload Failsafe reports
         uses: actions/upload-artifact@v4
         if: always()
@@ -125,16 +167,120 @@ jobs:
           path: backend/target/failsafe-reports/
           retention-days: 7
 
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Backend · Integration tests (report)
+          path: backend/target/failsafe-reports/TEST-*.xml
+          reporter: java-junit
+          fail-on-error: 'true'
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-integration-coverage
+          path: backend/target/site/jacoco/
+          retention-days: 7
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Backend · Integration tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Total | Passed | Failed | Errors | Skipped | Coverage |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|--------|--------|---------|----------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ${{ steps.counts.outputs.total }} | ${{ steps.counts.outputs.passed }} | ${{ steps.counts.outputs.failed }} | ${{ steps.counts.outputs.errors }} | ${{ steps.counts.outputs.skipped }} | ${{ steps.counts.outputs.coverage }}% |" >> "$GITHUB_STEP_SUMMARY"
+
   # ──────────────────────────────────────────────
-  # Job 3: Verificar la build de producción
-  # Garantiza que las imágenes de producción compilan ANTES de poder
-  # mergear a main, evitando builds rotas en main que bloquean el deploy.
-  # No se publican imágenes aquí — solo se valida que la build pasa.
-  # Reutiliza los mismos scopes de caché gha que el workflow de deploy,
-  # de forma que el build posterior al merge arranca con caché caliente.
+  # Frontend · Pruebas unitarias (Vitest)
+  # ──────────────────────────────────────────────
+  frontend-unit:
+    name: Frontend · Unit tests
+    runs-on: ubuntu-latest
+    outputs:
+      total: ${{ steps.counts.outputs.total }}
+      passed: ${{ steps.counts.outputs.passed }}
+      failed: ${{ steps.counts.outputs.failed }}
+      errors: ${{ steps.counts.outputs.errors }}
+      skipped: ${{ steps.counts.outputs.skipped }}
+      coverage: ${{ steps.counts.outputs.coverage }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run unit tests + coverage
+        working-directory: frontend
+        run: npm run test:ci
+
+      - name: Compute counts & coverage
+        id: counts
+        if: always()
+        run: |
+          source .github/scripts/junit-counts.sh frontend/test-results/junit.xml
+          {
+            echo "total=$TOTAL"
+            echo "passed=$PASSED"
+            echo "failed=$FAILURES"
+            echo "errors=$ERRORS"
+            echo "skipped=$SKIPPED"
+            echo "coverage=$(.github/scripts/lcov-coverage.sh frontend/coverage/frontend/lcov.info)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload Vitest report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-vitest-report
+          path: frontend/test-results/
+          retention-days: 7
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Frontend · Unit tests (report)
+          path: frontend/test-results/junit.xml
+          reporter: jest-junit
+          fail-on-error: 'true'
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          retention-days: 7
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Frontend · Unit tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Total | Passed | Failed | Errors | Skipped | Coverage |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|--------|--------|---------|----------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ${{ steps.counts.outputs.total }} | ${{ steps.counts.outputs.passed }} | ${{ steps.counts.outputs.failed }} | ${{ steps.counts.outputs.errors }} | ${{ steps.counts.outputs.skipped }} | ${{ steps.counts.outputs.coverage }}% |" >> "$GITHUB_STEP_SUMMARY"
+
+  # ──────────────────────────────────────────────
+  # Build · Verificar imágenes de producción
+  # Garantiza que las imágenes de producción compilan ANTES de mergear a main,
+  # evitando builds rotas en main que bloquean el deploy. No publica imágenes.
   # ──────────────────────────────────────────────
   build-verification:
-    name: Verificar build de producción
+    name: Build · Production images
     runs-on: ubuntu-latest
 
     steps:
@@ -166,3 +312,149 @@ jobs:
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
 
+  # ──────────────────────────────────────────────
+  # CI · Notificación de resultados
+  # Agrega conteos y cobertura de las tres suites + estado del build y:
+  #   - en PRs: publica/actualiza un comentario sticky;
+  #   - siempre (PR y push a main): envía un embed a Discord.
+  # Corre always(): notifica también cuando algo falla.
+  # ──────────────────────────────────────────────
+  ci-notify:
+    name: CI · Notify results
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [backend-unit, backend-integration, frontend-unit, build-verification]
+    permissions:
+      pull-requests: write
+
+    env:
+      # Resultado de cada job (success/failure/cancelled/skipped).
+      BU_RESULT: ${{ needs.backend-unit.result }}
+      BI_RESULT: ${{ needs.backend-integration.result }}
+      FE_RESULT: ${{ needs.frontend-unit.result }}
+      BUILD_RESULT: ${{ needs.build-verification.result }}
+      # Conteos y cobertura. Pueden venir vacíos si un job no llegó a calcularlos.
+      BU_TOTAL: ${{ needs.backend-unit.outputs.total }}
+      BU_PASSED: ${{ needs.backend-unit.outputs.passed }}
+      BU_FAILED: ${{ needs.backend-unit.outputs.failed }}
+      BU_ERRORS: ${{ needs.backend-unit.outputs.errors }}
+      BU_SKIPPED: ${{ needs.backend-unit.outputs.skipped }}
+      BU_COV: ${{ needs.backend-unit.outputs.coverage }}
+      BI_TOTAL: ${{ needs.backend-integration.outputs.total }}
+      BI_PASSED: ${{ needs.backend-integration.outputs.passed }}
+      BI_FAILED: ${{ needs.backend-integration.outputs.failed }}
+      BI_ERRORS: ${{ needs.backend-integration.outputs.errors }}
+      BI_SKIPPED: ${{ needs.backend-integration.outputs.skipped }}
+      BI_COV: ${{ needs.backend-integration.outputs.coverage }}
+      FE_TOTAL: ${{ needs.frontend-unit.outputs.total }}
+      FE_PASSED: ${{ needs.frontend-unit.outputs.passed }}
+      FE_FAILED: ${{ needs.frontend-unit.outputs.failed }}
+      FE_ERRORS: ${{ needs.frontend-unit.outputs.errors }}
+      FE_SKIPPED: ${{ needs.frontend-unit.outputs.skipped }}
+      FE_COV: ${{ needs.frontend-unit.outputs.coverage }}
+      # Contexto del evento (PR vs push a main).
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      TARGET_URL: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Build summary
+        run: |
+          # Normaliza un número (vacío -> 0) y una cobertura (vacío -> "n/a").
+          n() { echo "${1:-0}"; }
+          cov() { [ -n "$1" ] && echo "$1%" || echo "n/a"; }
+          emoji() { [ "$1" = "success" ] && echo "✅" || echo "❌"; }
+
+          TOTAL=$(( $(n "$BU_TOTAL") + $(n "$BI_TOTAL") + $(n "$FE_TOTAL") ))
+
+          # Estado global: éxito sólo si los cuatro jobs pasaron.
+          OVERALL=success
+          for r in "$BU_RESULT" "$BI_RESULT" "$FE_RESULT" "$BUILD_RESULT"; do
+            [ "$r" != "success" ] && OVERALL=failure
+          done
+
+          # Markdown para el comentario del PR / step summary.
+          {
+            echo "## 🧪 Resultados de CI"
+            echo ""
+            echo "| Suite | Total | ✅ Passed | ❌ Failed | ⚠️ Errors | ⏭️ Skipped | 📊 Coverage |"
+            echo "|-------|------:|--------:|--------:|--------:|---------:|----------:|"
+            echo "| $(emoji "$BU_RESULT") Backend · Unit | $(n "$BU_TOTAL") | $(n "$BU_PASSED") | $(n "$BU_FAILED") | $(n "$BU_ERRORS") | $(n "$BU_SKIPPED") | $(cov "$BU_COV") |"
+            echo "| $(emoji "$BI_RESULT") Backend · Integration | $(n "$BI_TOTAL") | $(n "$BI_PASSED") | $(n "$BI_FAILED") | $(n "$BI_ERRORS") | $(n "$BI_SKIPPED") | $(cov "$BI_COV") |"
+            echo "| $(emoji "$FE_RESULT") Frontend · Unit | $(n "$FE_TOTAL") | $(n "$FE_PASSED") | $(n "$FE_FAILED") | $(n "$FE_ERRORS") | $(n "$FE_SKIPPED") | $(cov "$FE_COV") |"
+            echo ""
+            echo "**Total de pruebas ejecutadas: $TOTAL** · Build de imágenes: $(emoji "$BUILD_RESULT")"
+            echo ""
+            echo "<sub>commit \`$HEAD_SHA\` · [ver run]($RUN_URL)</sub>"
+          } > comment.md
+          cat comment.md >> "$GITHUB_STEP_SUMMARY"
+
+          # Exporta valores normalizados para el paso de Discord.
+          {
+            echo "OVERALL=$OVERALL"
+            echo "TOTAL=$TOTAL"
+            echo "F_BU=$(emoji "$BU_RESULT") $(n "$BU_PASSED")/$(n "$BU_TOTAL") · cov $(cov "$BU_COV")"
+            echo "F_BI=$(emoji "$BI_RESULT") $(n "$BI_PASSED")/$(n "$BI_TOTAL") · cov $(cov "$BI_COV")"
+            echo "F_FE=$(emoji "$FE_RESULT") $(n "$FE_PASSED")/$(n "$FE_TOTAL") · cov $(cov "$FE_COV")"
+            echo "F_BUILD=$(emoji "$BUILD_RESULT") $BUILD_RESULT"
+          } >> "$GITHUB_ENV"
+
+      - name: Post sticky comment
+        if: github.event_name == 'pull_request_target'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.pull_request.number }}
+          header: ci-test-summary
+          path: comment.md
+
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK_URL no configurado; se omite la notificación."
+            exit 0
+          fi
+
+          if [ "$OVERALL" = "success" ]; then
+            COLOR=5763719; STATUS_EMOJI="✅"; STATUS_TXT="CI en verde"
+          else
+            COLOR=15548997; STATUS_EMOJI="❌"; STATUS_TXT="CI con fallos"
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            CONTEXT="PR #$PR_NUMBER"
+          else
+            CONTEXT="push a main"
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg title "$STATUS_EMOJI $STATUS_TXT — $CONTEXT" \
+            --arg url "$TARGET_URL" \
+            --arg desc "**$TOTAL** pruebas ejecutadas · commit \`$HEAD_SHA\`" \
+            --argjson color "$COLOR" \
+            --arg f_bu "$F_BU" \
+            --arg f_bi "$F_BI" \
+            --arg f_fe "$F_FE" \
+            --arg f_build "$F_BUILD" \
+            --arg run_url "$RUN_URL" \
+            --arg footer "GitHub Actions • ${{ github.repository }}" \
+            '{embeds:[{
+               title: $title,
+               url: $url,
+               description: ($desc + "\n[Ver ejecución completa](" + $run_url + ")"),
+               color: $color,
+               fields: [
+                 {name:"Backend · Unit",        value:$f_bu,    inline:true},
+                 {name:"Backend · Integration", value:$f_bi,    inline:true},
+                 {name:"Frontend · Unit",       value:$f_fe,    inline:true},
+                 {name:"Build · Imágenes",      value:$f_build, inline:false}
+               ],
+               footer: {text: $footer}
+             }]}')
+
+          # No fallar el job si Discord tiene un hipo (rate limit, etc.).
+          curl -sf -X POST "$DISCORD_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" || echo "::warning::No se pudo enviar la notificación a Discord."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy — Production
 # Se dispara automáticamente cuando el workflow de CI pasa en main.
 on:
   workflow_run:
-    workflows: ["CI — Tests"]
+    workflows: ["CI"]
     branches: [main]
     types: [completed]
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -19,6 +19,7 @@
 		<springdoc.version>2.7.0</springdoc.version>
 		<aws.sdk.version>2.30.31</aws.sdk.version>
 		<lombok.version>1.18.42</lombok.version>
+		<jacoco.version>0.8.12</jacoco.version>
 	</properties>
 	<dependencies>
 
@@ -164,12 +165,40 @@
 						<include>**/*IT.java</include>
 						<include>**/it/**/*Test.java</include>
 					</includes>
+					<!-- @{argLine} se resuelve en tiempo de ejecución e incluye el
+					     agente de JaCoCo inyectado por jacoco:prepare-agent, de modo
+					     que las pruebas de integración también cuentan para la cobertura. -->
 					<argLine>
+						@{argLine}
 						--add-opens java.base/java.lang=ALL-UNNAMED
 						--add-opens java.base/java.lang.reflect=ALL-UNNAMED
 						--add-opens java.base/java.util=ALL-UNNAMED
 					</argLine>
 				</configuration>
+			</plugin>
+			<!-- Cobertura de código. El agente se inyecta vía la propiedad argLine,
+			     que Surefile (unit) y Failsafe (integración) incorporan en su JVM.
+			     Ambas suites escriben en target/jacoco.exec (append) y el informe
+			     agregado se genera en target/site/jacoco/jacoco.xml. -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/docs/arquitectura/deployment.md
+++ b/docs/arquitectura/deployment.md
@@ -39,7 +39,7 @@ graph TB
     end
 
     subgraph GitHub
-        GH_CI["CI — Tests\n(push a main)"]
+        GH_CI["CI\n(push a main)"]
         GH_Deploy["Deploy\n(tras CI verde)"]
         GHCR["GHCR\nimágenes backend/frontend"]
     end
@@ -73,14 +73,14 @@ El despliegue es **completamente automático**: cualquier push a `main` en el re
 sequenceDiagram
     participant Dev as Desarrollador
     participant GH as GitHub (main)
-    participant CI as CI — Tests
+    participant CI as CI
     participant Deploy as Deploy workflow
     participant GHCR as GHCR
     participant VPS as Servidor VPS
 
     Dev->>GH: git push / merge PR
-    GH->>CI: dispara CI — Tests
-    CI->>CI: test unitarios + integración
+    GH->>CI: dispara CI
+    CI->>CI: backend unit + integración + frontend + build
     alt CI falla
         CI-->>Dev: ❌ notificación
     else CI pasa

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log
 .sass-cache/
 /connect.lock
 /coverage
+/test-results
 /libpeerconnection.log
 testem.log
 /typings

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -77,7 +77,20 @@
           "defaultConfiguration": "development"
         },
         "test": {
-          "builder": "@angular/build:unit-test"
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "coverageReporters": ["text-summary", "lcovonly", "json", "html"],
+            "coverageExclude": [
+              "src/app/**/*.spec.ts",
+              "src/app/**/*.routes.ts",
+              "src/app/**/*.config.ts"
+            ]
+          },
+          "configurations": {
+            "ci": {
+              "reporters": ["verbose", ["junit", { "outputFile": "test-results/junit.xml" }]]
+            }
+          }
         }
       }
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@angular/cli": "^21.2.1",
         "@angular/compiler-cli": "^21.2.0",
         "@types/sockjs-client": "^1.5.4",
+        "@vitest/coverage-v8": "^4.0.8",
         "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "typescript": "~5.9.2",
@@ -850,9 +851,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -860,9 +861,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -894,13 +895,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -944,17 +945,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -3941,17 +3952,48 @@
         "vite": "^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3960,13 +4002,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3987,9 +4029,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4000,13 +4042,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4014,14 +4056,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4030,9 +4072,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4040,13 +4082,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4214,6 +4256,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -5481,6 +5542,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -5552,6 +5623,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -5834,6 +5912,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jose": {
@@ -6152,6 +6259,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -7921,6 +8056,19 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8262,19 +8410,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -8302,10 +8450,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -8327,6 +8477,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:ci": "ng test --no-watch --coverage --configuration ci"
   },
   "private": true,
   "packageManager": "npm@10.9.2",
@@ -27,6 +28,7 @@
     "@angular/cli": "^21.2.1",
     "@angular/compiler-cli": "^21.2.0",
     "@types/sockjs-client": "^1.5.4",
+    "@vitest/coverage-v8": "^4.0.8",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,10 +1,8 @@
 import { defineConfig } from 'vitest/config';
 
-const isCI = !!process.env['CI'];
-
+// El builder @angular/build:unit-test gestiona reporters y cobertura a través
+// de las opciones declaradas en angular.json (ver target "test"). Este fichero
+// queda para configuración propia de vitest que el builder sí respeta.
 export default defineConfig({
-  test: {
-    reporters: isCI ? ['verbose', 'junit'] : ['default'],
-    outputFile: isCI ? 'test-results/junit.xml' : undefined,
-  },
+  test: {},
 });


### PR DESCRIPTION
## 🚀 Mejoras de CI/CD: build obligatorio, feedback de tests y notificaciones a Discord

  ### Contexto
  El flujo de CI funcionaba, pero tenía tres problemas: el build de producción solo se verificaba *después* del merge (builds rotas llegaban a `main` y
  bloqueaban el deploy), el resumen de tests reportaba ~28 cuando hay 300+, y no había notificaciones de resultados fuera de GitHub.

  ### Cambios

  #### 1. Build obligatorio antes de mergear a `main`
  - Nuevo job **`Build · Production images`** que construye el target `production` de backend y frontend en cada PR.
  - Una build que no compila ya no se puede mergear → se acabaron los fallos de build en `main`.
  - Reutiliza el caché GHA, así que el build del deploy arranca caliente. No publica imágenes.

  #### 2. Feedback de tests y cobertura
  - **Frontend ahora corre en CI** (vitest) — antes no se ejecutaba en ningún sitio.
  - **Tests de integración (Failsafe)** ahora se publican con `dorny/test-reporter` (antes solo se subían como artifact).
  - **Conteo correcto y agregado** de las tres suites mediante scripts en `.github/scripts/`.
  - **Cobertura** con JaCoCo (backend) y `@vitest/coverage-v8` (frontend), medida localmente y publicada como artifacts HTML navegables.
  - **Comentario sticky** en el PR con tabla de tests + cobertura, que se actualiza en cada push.
  - Jobs renombrados a algo claro: `Backend · Unit tests`, `Backend · Integration tests`, `Frontend · Unit tests`, `Build · Production images`.

  #### 3. Notificaciones a Discord
  - Nuevo job `ci-notify` que envía un embed a Discord (reusando el webhook existente) en PRs **y** en push a `main`.
  - Verde/rojo según el resultado, con total de pruebas, cobertura por suite y estado del build.

  ### Ficheros tocados
  - `.github/workflows/ci.yml` (reescrito)
  - `.github/scripts/{junit-counts,jacoco-coverage,lcov-coverage}.sh` (nuevos)
  - `backend/pom.xml` (JaCoCo)
  - `frontend/{angular.json,package.json,vitest.config.ts,.gitignore}`
  - `.github/workflows/deploy.yml` y `docs/arquitectura/deployment.md` (renombrado del workflow `CI — Tests` → `CI`)

  ### ⚠️  Acción manual tras el merge
  Marcar como **checks obligatorios** en la branch protection de `main`: `Frontend · Unit tests`, `Backend · Integration tests` y `Build · Production
  images` (una vez hayan corrido al menos una vez).
