### PR TITLE
feat(#176): add public player profile page accessible from friends list

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -60,6 +60,11 @@ export const routes: Routes = [
     loadComponent: () => import('./features/player/pages/friends/friends').then(m => m.Friends),
   },
   {
+    path: 'players/:userId',
+    canActivate: [authGuard],
+    loadComponent: () => import('./features/player/pages/player-profile/player-profile').then(m => m.PlayerProfile),
+  },
+  {
     path: 'play',
     canActivate: [authGuard],
     children: [

--- a/frontend/src/app/features/player/pages/friends/friends.html
+++ b/frontend/src/app/features/player/pages/friends/friends.html
@@ -32,6 +32,7 @@
                     <strong>{{ request.requester.username }}</strong>
                     <span>Quiere agregarte a amigos.</span>
                   </div>
+                  <a class="btn btn--ghost btn--sm" [routerLink]="['/players', request.requester.userId]">PERFIL</a>
                   <button type="button" class="btn btn--primary btn--sm" (click)="acceptRequest(request)" [disabled]="busy()">ACEPTAR</button>
                   <button type="button" class="btn btn--ghost btn--sm" (click)="declineRequest(request)" [disabled]="busy()">RECHAZAR</button>
                 </div>
@@ -85,6 +86,7 @@
                 <strong>{{ user.username }}</strong>
                 <span>{{ relationLabel(user.relation) }}</span>
               </div>
+              <a class="btn btn--ghost btn--sm" [routerLink]="['/players', user.userId]">PERFIL</a>
               <button
                 type="button"
                 class="btn btn--ghost btn--sm"
@@ -120,6 +122,7 @@
                 <strong>{{ friend.username }}</strong>
                 <span>Disponible para invitacion.</span>
               </div>
+              <a class="btn btn--ghost btn--sm" [routerLink]="['/players', friend.userId]">PERFIL</a>
               <button type="button" class="btn btn--gold btn--sm" (click)="invite(friend)" [disabled]="busy()">INVITAR</button>
             </div>
           } @empty {

--- a/frontend/src/app/features/player/pages/friends/friends.ts
+++ b/frontend/src/app/features/player/pages/friends/friends.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { GameMode, MODE_LABELS } from '../../../../core/models/match.models';
 import {
   Friend,
@@ -17,7 +17,7 @@ type SocialMode = 'idle' | 'loading' | 'working';
 @Component({
   selector: 'app-friends',
   standalone: true,
-  imports: [TopbarComponent, AvatarComponent],
+  imports: [TopbarComponent, AvatarComponent, RouterLink],
   templateUrl: './friends.html',
   styleUrl: './friends.scss',
 })

--- a/frontend/src/app/features/player/pages/player-profile/player-profile.html
+++ b/frontend/src/app/features/player/pages/player-profile/player-profile.html
@@ -1,0 +1,73 @@
+<div class="vs-player-profile-page">
+  <app-topbar active="friends" />
+
+  <div class="vs-player-profile">
+
+    @if (loading()) {
+      <div class="vs-player-profile__loading">
+        <div class="vs-mono" style="color: var(--vs-text-muted); letter-spacing: 0.14em">CARGANDO PERFIL…</div>
+      </div>
+    } @else if (error()) {
+      <div class="vs-player-profile__error">
+        <div class="vs-alert vs-alert--err">{{ error() }}</div>
+        <button type="button" class="btn btn--ghost btn--sm" (click)="goBack()">← VOLVER</button>
+      </div>
+    } @else if (user()) {
+
+      <!-- Cabecera -->
+      <div class="vs-player-profile__head vs-card">
+        <vs-avatar [name]="user()!.username" [avatarUrl]="user()!.avatarUrl" [sizePx]="96" [fontSizePx]="34" />
+        <div style="flex: 1">
+          <div class="vs-display" style="font-size: 38px; line-height: 1">{{ user()!.username }}</div>
+          <div style="color: var(--vs-text-secondary); margin-top: 6px; font-size: 13px">
+            Se unió en {{ joined() }}
+          </div>
+          @if (user()!.role && user()!.role !== 'PLAYER') {
+            <span class="vs-meta-chip" style="margin-top: 8px; display: inline-block">
+              <strong>{{ user()!.role }}</strong>
+            </span>
+          }
+        </div>
+        <button type="button" class="btn btn--ghost btn--sm" (click)="goBack()">← VOLVER</button>
+      </div>
+
+      <!-- Rankings competitivos -->
+      <div>
+        <div class="vs-section-title">Clasificación competitiva</div>
+        @if (competitiveRows().length === 0) {
+          <div class="vs-card">
+            <div class="vs-empty">Este jugador aún no tiene partidas competitivas.</div>
+          </div>
+        } @else {
+          <div class="vs-card" style="padding: 0">
+            <table class="vs-table">
+              <thead>
+                <tr>
+                  <th>Modo</th>
+                  <th>#</th>
+                  <th>ELO</th>
+                  <th>% Victorias</th>
+                  <th>V/D</th>
+                  <th>Racha</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (row of competitiveRows(); track row.mode) {
+                  <tr>
+                    <td style="font-weight: 600">{{ row.mode }}</td>
+                    <td class="vs-mono" style="color: var(--vs-text-muted)">#{{ row.rank }}</td>
+                    <td class="vs-mono" style="color: var(--vs-accent-gold)">{{ row.rating }}</td>
+                    <td class="vs-mono" style="color: var(--vs-accent-green)">{{ row.winRate }}</td>
+                    <td class="vs-mono">{{ row.record }}</td>
+                    <td class="vs-mono" style="color: var(--vs-accent-blue)">{{ row.winStreak }}</td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+      </div>
+
+    }
+  </div>
+</div>

--- a/frontend/src/app/features/player/pages/player-profile/player-profile.scss
+++ b/frontend/src/app/features/player/pages/player-profile/player-profile.scss
@@ -1,0 +1,33 @@
+.vs-player-profile-page {
+  width: 100%;
+  min-height: 100vh;
+  background: var(--vs-bg-base);
+  display: flex;
+  flex-direction: column;
+}
+
+.vs-player-profile {
+  padding: 36px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.vs-player-profile__head {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 28px;
+}
+
+.vs-player-profile__loading,
+.vs-player-profile__error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 80px 0;
+}

--- a/frontend/src/app/features/player/pages/player-profile/player-profile.ts
+++ b/frontend/src/app/features/player/pages/player-profile/player-profile.ts
@@ -1,0 +1,86 @@
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Location } from '@angular/common';
+import { TopbarComponent } from '../../../../shared/components/layout/topbar/topbar';
+import { AvatarComponent } from '../../../../shared/components/ui/avatar/avatar.component';
+import { RankingService } from '../../../../core/services/ranking.service';
+import { PublicRankingUser, RankingSummary } from '../../../../core/models/ranking.models';
+import { GameMode } from '../../../../core/models/game.models';
+
+const MODE_LABEL: Record<GameMode, string> = {
+  SURVIVAL: 'Supervivencia',
+  PRECISION: 'Precisión',
+  BINARY_DUEL: 'Duelo binario',
+  PRECISION_DUEL: 'Duelo de precisión',
+  SABOTAGE: 'Sabotaje',
+};
+
+const MULTIPLAYER_MODES: GameMode[] = ['BINARY_DUEL', 'PRECISION_DUEL', 'SABOTAGE'];
+
+@Component({
+  selector: 'app-player-profile',
+  standalone: true,
+  imports: [TopbarComponent, AvatarComponent],
+  templateUrl: './player-profile.html',
+  styleUrl: './player-profile.scss',
+})
+export class PlayerProfile implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly rankingApi = inject(RankingService);
+  private readonly location = inject(Location);
+
+  readonly user = signal<PublicRankingUser | null>(null);
+  readonly rankings = signal<RankingSummary[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  readonly joined = computed(() => {
+    const iso = this.user()?.createdAt;
+    if (!iso) return '—';
+    return new Date(iso).toLocaleDateString('es-ES', { month: 'long', year: 'numeric' });
+  });
+
+  readonly competitiveRows = computed(() =>
+    this.rankings()
+      .filter((r) => MULTIPLAYER_MODES.includes(r.mode))
+      .map((r) => {
+        const total = r.wins + r.losses;
+        return {
+          mode: MODE_LABEL[r.mode] ?? r.mode,
+          rating: r.rating,
+          rank: r.rank,
+          winRate: total === 0 ? '0%' : `${Math.round((r.wins / total) * 100)}%`,
+          record: `${r.wins}/${r.losses}`,
+          winStreak: r.winStreak,
+        };
+      })
+  );
+
+  ngOnInit(): void {
+    const userId = this.route.snapshot.paramMap.get('userId');
+    if (!userId) {
+      this.error.set('ID de usuario no válido.');
+      this.loading.set(false);
+      return;
+    }
+    this.rankingApi.userRanking(userId).subscribe({
+      next: (data) => {
+        this.user.set(data.user);
+        this.rankings.set(data.rankings ?? []);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('No se pudo cargar el perfil de este jugador.');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  goBack(): void {
+    this.location.back();
+  }
+
+  modeLabel(mode: GameMode): string {
+    return MODE_LABEL[mode] ?? mode;
+  }
+}


### PR DESCRIPTION
- New route /players/:userId (auth-guarded): loads PublicRankingUser data and RankingSummary[] via GET /api/users/:id/ranking (existing endpoint)
- PlayerProfile component shows avatar, username, join date, role badge, and competitive ELO table (mode, rank, rating, win%, W/D record, streak)
- Location.back() on the back button preserves navigation history
- friends.html: PERFIL button added to friends list, search results, and incoming friend requests — all use routerLink to /players/:userId
- friends.ts: RouterLink added to component imports